### PR TITLE
Add health check endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ docker run -d --name cleanuparr \
   ghcr.io/cleanuparr/cleanuparr:latest
 ```
 
-All installation methods are available [here](https://cleanuparr.github.io/Cleanuparr/docs/installation/detailed).
+For Docker Compose, health checks, and other installation methods, see our [Complete Installation Guide](https://cleanuparr.github.io/Cleanuparr/docs/installation/detailed).
 
 ### 🌐 Access the Web Interface
 

--- a/code/backend/Cleanuparr.Api/Controllers/HealthController.cs
+++ b/code/backend/Cleanuparr.Api/Controllers/HealthController.cs
@@ -1,0 +1,125 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Cleanuparr.Api.Controllers;
+
+/// <summary>
+/// Health check endpoints for Docker and Kubernetes
+/// </summary>
+[ApiController]
+[Route("[controller]")]
+public class HealthController : ControllerBase
+{
+    private readonly HealthCheckService _healthCheckService;
+    private readonly ILogger<HealthController> _logger;
+
+    public HealthController(HealthCheckService healthCheckService, ILogger<HealthController> logger)
+    {
+        _healthCheckService = healthCheckService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Basic liveness probe - checks if the application is running
+    /// Used by Docker HEALTHCHECK and Kubernetes liveness probes
+    /// </summary>
+    [HttpGet]
+    [Route("/health")]
+    public async Task<IActionResult> GetHealth()
+    {
+        try
+        {
+            var result = await _healthCheckService.CheckHealthAsync(
+                registration => registration.Tags.Contains("liveness"));
+            
+            return result.Status == HealthStatus.Healthy 
+                ? Ok(new { status = "healthy", timestamp = DateTime.UtcNow })
+                : StatusCode(503, new { status = "unhealthy", timestamp = DateTime.UtcNow });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Health check failed");
+            return StatusCode(503, new { status = "unhealthy", error = "Health check failed", timestamp = DateTime.UtcNow });
+        }
+    }
+
+    /// <summary>
+    /// Readiness probe - checks if the application is ready to serve traffic
+    /// Used by Kubernetes readiness probes
+    /// </summary>
+    [HttpGet]
+    [Route("/health/ready")]
+    public async Task<IActionResult> GetReadiness()
+    {
+        try
+        {
+            var result = await _healthCheckService.CheckHealthAsync(
+                registration => registration.Tags.Contains("readiness"));
+            
+            if (result.Status == HealthStatus.Healthy)
+            {
+                return Ok(new { status = "ready", timestamp = DateTime.UtcNow });
+            }
+            
+            // For readiness, we consider degraded as not ready
+            return StatusCode(503, new { 
+                status = "not_ready", 
+                timestamp = DateTime.UtcNow,
+                details = result.Entries.Where(e => e.Value.Status != HealthStatus.Healthy)
+                    .ToDictionary(e => e.Key, e => new { 
+                        status = e.Value.Status.ToString().ToLowerInvariant(),
+                        description = e.Value.Description 
+                    })
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Readiness check failed");
+            return StatusCode(503, new { status = "not_ready", error = "Readiness check failed", timestamp = DateTime.UtcNow });
+        }
+    }
+
+    /// <summary>
+    /// Detailed health status - for monitoring and debugging
+    /// </summary>
+    [HttpGet]
+    [Route("/health/detailed")]
+    public async Task<IActionResult> GetDetailedHealth()
+    {
+        try
+        {
+            var result = await _healthCheckService.CheckHealthAsync();
+            
+            var response = new
+            {
+                status = result.Status.ToString().ToLowerInvariant(),
+                timestamp = DateTime.UtcNow,
+                totalDuration = result.TotalDuration.TotalMilliseconds,
+                entries = result.Entries.ToDictionary(
+                    e => e.Key,
+                    e => new
+                    {
+                        status = e.Value.Status.ToString().ToLowerInvariant(),
+                        description = e.Value.Description,
+                        duration = e.Value.Duration.TotalMilliseconds,
+                        tags = e.Value.Tags,
+                        data = e.Value.Data,
+                        exception = e.Value.Exception?.Message
+                    })
+            };
+
+            return result.Status == HealthStatus.Healthy 
+                ? Ok(response)
+                : StatusCode(503, response);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Detailed health check failed");
+            return StatusCode(503, new { 
+                status = "unhealthy", 
+                error = "Detailed health check failed", 
+                timestamp = DateTime.UtcNow 
+            });
+        }
+    }
+} 

--- a/code/backend/Cleanuparr.Api/DependencyInjection/MainDI.cs
+++ b/code/backend/Cleanuparr.Api/DependencyInjection/MainDI.cs
@@ -83,9 +83,17 @@ public static class MainDI
     /// </summary>
     private static IServiceCollection AddHealthServices(this IServiceCollection services) =>
         services
-            // Register the health check service
+            // Register the existing health check service for download clients
             .AddSingleton<IHealthCheckService, HealthCheckService>()
             
             // Register the background service for periodic health checks
-            .AddHostedService<HealthCheckBackgroundService>();
+            .AddHostedService<HealthCheckBackgroundService>()
+            
+            // Add ASP.NET Core health checks
+            .AddHealthChecks()
+                .AddCheck<ApplicationHealthCheck>("application", tags: ["liveness"])
+                .AddCheck<DatabaseHealthCheck>("database", tags: ["readiness"])
+                .AddCheck<FileSystemHealthCheck>("filesystem", tags: ["readiness"])
+                .AddCheck<DownloadClientsHealthCheck>("download_clients", tags: ["readiness"])
+            .Services;
 }

--- a/code/backend/Cleanuparr.Api/HealthCheckResponseWriter.cs
+++ b/code/backend/Cleanuparr.Api/HealthCheckResponseWriter.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using System.Text;
+
+namespace Cleanuparr.Api;
+
+/// <summary>
+/// Custom health check response writers for different formats
+/// </summary>
+public static class HealthCheckResponseWriter
+{
+    /// <summary>
+    /// Writes a minimal plain text response suitable for Docker health checks
+    /// </summary>
+    public static async Task WriteMinimalPlaintext(HttpContext context, HealthReport report)
+    {
+        context.Response.ContentType = "text/plain";
+        
+        var status = report.Status switch
+        {
+            HealthStatus.Healthy => "healthy",
+            HealthStatus.Degraded => "degraded", 
+            HealthStatus.Unhealthy => "unhealthy",
+            _ => "unknown"
+        };
+
+        await context.Response.WriteAsync(status, Encoding.UTF8);
+    }
+} 

--- a/code/backend/Cleanuparr.Api/Program.cs
+++ b/code/backend/Cleanuparr.Api/Program.cs
@@ -4,6 +4,8 @@ using Cleanuparr.Api;
 using Cleanuparr.Api.DependencyInjection;
 using Cleanuparr.Infrastructure.Logging;
 using Cleanuparr.Shared.Helpers;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Serilog;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -146,6 +148,19 @@ logConfig.MinimumLevel.ControlledBy(levelSwitch);
 logConfig.WriteTo.Sink(signalRSink);
 
 Log.Logger = logConfig.CreateLogger();
+
+// Configure health check endpoints before the API configuration
+app.MapHealthChecks("/health", new HealthCheckOptions
+{
+    Predicate = registration => registration.Tags.Contains("liveness"),
+    ResponseWriter = HealthCheckResponseWriter.WriteMinimalPlaintext
+});
+
+app.MapHealthChecks("/health/ready", new HealthCheckOptions
+{
+    Predicate = registration => registration.Tags.Contains("readiness"),
+    ResponseWriter = HealthCheckResponseWriter.WriteMinimalPlaintext
+});
 
 app.ConfigureApi();
 

--- a/code/backend/Cleanuparr.Infrastructure/Cleanuparr.Infrastructure.csproj
+++ b/code/backend/Cleanuparr.Infrastructure/Cleanuparr.Infrastructure.csproj
@@ -16,6 +16,7 @@
       <PackageReference Include="Mapster" Version="7.4.0" />
       <PackageReference Include="MassTransit.Abstractions" Version="8.4.1" />
       <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.0" />
+      <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="9.0.0" />
       <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.6" />
       <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.6" />
       <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.6" />

--- a/code/backend/Cleanuparr.Infrastructure/Health/ApplicationHealthCheck.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/ApplicationHealthCheck.cs
@@ -1,0 +1,16 @@
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Cleanuparr.Infrastructure.Health;
+
+/// <summary>
+/// Basic application health check that verifies the application is running
+/// </summary>
+public class ApplicationHealthCheck : IHealthCheck
+{
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        // Basic liveness check - if we can execute this, the app is running
+        return Task.FromResult(HealthCheckResult.Healthy("Application is running"));
+    }
+} 

--- a/code/backend/Cleanuparr.Infrastructure/Health/DatabaseHealthCheck.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/DatabaseHealthCheck.cs
@@ -1,0 +1,50 @@
+using Cleanuparr.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace Cleanuparr.Infrastructure.Health;
+
+/// <summary>
+/// Health check that verifies database connectivity
+/// </summary>
+public class DatabaseHealthCheck : IHealthCheck
+{
+    private readonly DataContext _dataContext;
+    private readonly ILogger<DatabaseHealthCheck> _logger;
+
+    public DatabaseHealthCheck(DataContext dataContext, ILogger<DatabaseHealthCheck> logger)
+    {
+        _dataContext = dataContext;
+        _logger = logger;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Try to execute a simple query to verify database connectivity
+            var canConnect = await _dataContext.Database.CanConnectAsync(cancellationToken);
+            
+            if (!canConnect)
+            {
+                return HealthCheckResult.Unhealthy("Cannot connect to database");
+            }
+
+            // Optionally check if database schema is up to date
+            var pendingMigrations = await _dataContext.Database.GetPendingMigrationsAsync(cancellationToken);
+            if (pendingMigrations.Any())
+            {
+                _logger.LogWarning("Database has pending migrations: {migrations}", string.Join(", ", pendingMigrations));
+                return HealthCheckResult.Degraded($"Database has {pendingMigrations.Count()} pending migrations");
+            }
+
+            return HealthCheckResult.Healthy("Database connection successful");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Database health check failed");
+            return HealthCheckResult.Unhealthy("Database health check failed", ex);
+        }
+    }
+} 

--- a/code/backend/Cleanuparr.Infrastructure/Health/DownloadClientsHealthCheck.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/DownloadClientsHealthCheck.cs
@@ -1,0 +1,60 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace Cleanuparr.Infrastructure.Health;
+
+/// <summary>
+/// Health check that verifies download clients are healthy
+/// </summary>
+public class DownloadClientsHealthCheck : IHealthCheck
+{
+    private readonly IHealthCheckService _healthCheckService;
+    private readonly ILogger<DownloadClientsHealthCheck> _logger;
+
+    public DownloadClientsHealthCheck(IHealthCheckService healthCheckService, ILogger<DownloadClientsHealthCheck> logger)
+    {
+        _healthCheckService = healthCheckService;
+        _logger = logger;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            // Get current health status of all clients without triggering new checks
+            var allClientHealth = _healthCheckService.GetAllClientHealth();
+            
+            if (!allClientHealth.Any())
+            {
+                // No clients configured - this might be ok depending on the deployment
+                return HealthCheckResult.Healthy("No download clients configured");
+            }
+
+            var healthyClients = allClientHealth.Values.Where(h => h.IsHealthy).ToList();
+            var unhealthyClients = allClientHealth.Values.Where(h => !h.IsHealthy).ToList();
+            var totalClients = allClientHealth.Count;
+
+            if (unhealthyClients.Any())
+            {
+                var unhealthyNames = string.Join(", ", unhealthyClients.Select(c => c.ClientName));
+                var message = $"{unhealthyClients.Count}/{totalClients} download clients unhealthy: {unhealthyNames}";
+                
+                // If more than half are unhealthy, consider it unhealthy
+                if (unhealthyClients.Count > totalClients / 2)
+                {
+                    return HealthCheckResult.Unhealthy(message);
+                }
+                
+                // Otherwise, it's degraded
+                return HealthCheckResult.Degraded(message);
+            }
+
+            return HealthCheckResult.Healthy($"All {totalClients} download clients are healthy");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Download clients health check failed");
+            return HealthCheckResult.Unhealthy("Download clients health check failed", ex);
+        }
+    }
+} 

--- a/code/backend/Cleanuparr.Infrastructure/Health/FileSystemHealthCheck.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/FileSystemHealthCheck.cs
@@ -1,0 +1,76 @@
+using Cleanuparr.Shared.Helpers;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+namespace Cleanuparr.Infrastructure.Health;
+
+/// <summary>
+/// Health check that verifies file system access to critical directories
+/// </summary>
+public class FileSystemHealthCheck : IHealthCheck
+{
+    private readonly ILogger<FileSystemHealthCheck> _logger;
+
+    public FileSystemHealthCheck(ILogger<FileSystemHealthCheck> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var issues = new List<string>();
+
+            // Check config directory access
+            var configPath = ConfigurationPathProvider.GetConfigPath();
+            if (!CheckDirectoryAccess(configPath, "config"))
+            {
+                issues.Add($"Cannot access config directory: {configPath}");
+            }
+
+            // Check current working directory
+            var currentDir = Directory.GetCurrentDirectory();
+            if (!CheckDirectoryAccess(currentDir, "working"))
+            {
+                issues.Add($"Cannot access working directory: {currentDir}");
+            }
+
+            if (issues.Any())
+            {
+                var message = $"File system issues detected: {string.Join(", ", issues)}";
+                return Task.FromResult(HealthCheckResult.Unhealthy(message));
+            }
+
+            return Task.FromResult(HealthCheckResult.Healthy("File system access verified"));
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "File system health check failed");
+            return Task.FromResult(HealthCheckResult.Unhealthy("File system health check failed", ex));
+        }
+    }
+
+    private bool CheckDirectoryAccess(string path, string description)
+    {
+        try
+        {
+            if (!Directory.Exists(path))
+            {
+                _logger.LogWarning("Directory does not exist: {path} ({description})", path, description);
+                return false;
+            }
+
+            // Try to enumerate directory contents
+            _ = Directory.GetFiles(path).Take(1).ToList();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Cannot access {description} directory: {path}", description, path);
+            return false;
+        }
+    }
+
+
+} 

--- a/docs/docs/configuration/health-checks/index.mdx
+++ b/docs/docs/configuration/health-checks/index.mdx
@@ -1,0 +1,195 @@
+---
+sidebar_position: 8
+---
+
+import { Important, Warning } from '@site/src/components/Admonition';
+import { 
+  ConfigSection, 
+  EnhancedImportant, 
+  EnhancedWarning,
+  styles 
+} from '@site/src/components/documentation';
+
+# Health Checks
+
+Cleanuparr provides comprehensive health check endpoints that are compatible with Docker health checks and Kubernetes probes. This allows for better monitoring, automated failover, and container orchestration.
+
+<div className={styles.documentationPage}>
+
+<div className={styles.section}>
+
+<h2 className={styles.sectionTitle}>
+  <span className={styles.sectionIcon}>🏥</span>
+  Health Check Endpoints
+</h2>
+
+<ConfigSection
+  id="health-liveness"
+  title="/health - Liveness Probe"
+  icon="💓"
+>
+
+**Purpose**: Basic liveness check to verify the application is running  
+**Use Case**: Docker HEALTHCHECK and Kubernetes liveness probes  
+**Response**: HTTP 200 (healthy) or 503 (unhealthy)  
+**Checks**: Application startup and basic functionality
+
+```bash
+curl http://localhost:11011/health
+```
+
+</ConfigSection>
+
+<ConfigSection
+  id="health-readiness"
+  title="/health/ready - Readiness Probe"
+  icon="✅"
+>
+
+**Purpose**: Verify the application is ready to serve traffic  
+**Use Case**: Kubernetes readiness probes and load balancer health checks  
+**Response**: HTTP 200 (ready) or 503 (not ready)  
+**Checks**: Database connectivity, file system access, download client health
+
+```bash
+curl http://localhost:11011/health/ready
+```
+
+</ConfigSection>
+
+<ConfigSection
+  id="health-detailed"
+  title="/health/detailed - Detailed Status"
+  icon="📊"
+>
+
+**Purpose**: Comprehensive health status for monitoring and debugging  
+**Use Case**: Monitoring systems and troubleshooting  
+**Response**: Detailed JSON with status of all components  
+**Checks**: All health checks with timing and detailed status
+
+```bash
+curl http://localhost:11011/health/detailed
+```
+
+</ConfigSection>
+
+</div>
+
+<div className={styles.section}>
+
+<h2 className={styles.sectionTitle}>
+  <span className={styles.sectionIcon}>🔍</span>
+  Health Check Components
+</h2>
+
+<ConfigSection
+  id="application-health"
+  title="Application Health"
+  icon="🚀"
+>
+
+- Verifies the application is running and responsive
+- Basic functionality test
+- Used for liveness probes
+
+</ConfigSection>
+
+<ConfigSection
+  id="database-health"
+  title="Database Health"
+  icon="🗄️"
+>
+
+- Tests database connectivity
+- Checks for pending migrations
+- Validates schema integrity
+- Used for readiness probes
+
+</ConfigSection>
+
+<ConfigSection
+  id="filesystem-health"
+  title="File System Health"
+  icon="📁"
+>
+
+- Verifies access to configuration directories
+- Validates working directory access
+- Used for readiness probes
+
+<EnhancedImportant>
+File write tests are not performed during health checks to avoid creating temporary files on every check.
+</EnhancedImportant>
+
+</ConfigSection>
+
+<ConfigSection
+  id="download-client-health"
+  title="Download Client Health"
+  icon="⬇️"
+>
+
+- Integrates with existing download client monitoring
+- Reports status of all configured download clients
+- Considers overall health based on client availability
+- Used for readiness probes
+
+</ConfigSection>
+
+</div>
+
+<div className={styles.section}>
+
+<h2 className={styles.sectionTitle}>
+  <span className={styles.sectionIcon}>🐳</span>
+  Environment Variables
+</h2>
+
+<ConfigSection
+  id="health-environment-variables"
+  title="Environment Variables"
+  icon="🌍"
+>
+
+Health check endpoints are affected by these environment variables:
+
+- **`PORT`**: Application port (default: 11011)
+- **`BASE_PATH`**: Base path for the application (affects health check URLs)
+
+If you set `BASE_PATH=/cleanuparr`, health checks will be available at:
+- `localhost:[PORT]/cleanuparr/health`
+- `localhost:[PORT]/cleanuparr/health/ready`
+- `localhost:[PORT]/cleanuparr/health/detailed`
+
+</ConfigSection>
+
+</div>
+
+<div className={styles.section}>
+
+<h2 className={styles.sectionTitle}>
+  <span className={styles.sectionIcon}>🔧</span>
+  Troubleshooting
+</h2>
+
+<ConfigSection
+  id="health-common-issues"
+  title="Common Issues"
+  icon="⚠️"
+>
+
+**Health check timeout**  
+Increase timeout values if the application is slow to respond
+
+**File system permission errors**  
+Check container user permissions and mount points
+
+**Download client unavailability**  
+Review download client configurations and network connectivity
+
+</ConfigSection>
+
+</div>
+
+</div> 

--- a/docs/docs/installation/detailed.mdx
+++ b/docs/docs/installation/detailed.mdx
@@ -77,6 +77,13 @@ services:
       - PGID=1000
       - UMASK=022
       - TZ=Etc/UTC
+    # Health check configuration
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:11011/health"]
+      interval: 30s        # Check every 30 seconds
+      timeout: 10s         # Allow up to 10 seconds for response
+      start_period: 30s    # Wait 30 seconds before first check
+      retries: 3           # Mark unhealthy after 3 consecutive failures
 ```
 
 ### Environment Variables
@@ -257,3 +264,6 @@ To run Cleanuparr as a systemd service:
 - **Web Interface**: `http://localhost:11011`
 - **Base Path**: *(empty)* (for reverse proxy setups, change `BASE_PATH` environment variable)
 - **Configuration Location**: Varies by platform and installation method
+
+#### Health Checks
+Cleanuparr provides comprehensive health check endpoints for monitoring and container orchestration. For detailed information about available endpoints and configuration, see the [Health Checks documentation](../configuration/health-checks/).


### PR DESCRIPTION
Relates to #163

Implemented health check endpoints to give the user full control over health checks instead of forcing them inside the Docker image.