### PR TITLE
Fix stale health statuses for clients that have been removed

### DIFF
--- a/code/backend/Cleanuparr.Infrastructure.Tests/Health/HealthCheckServiceTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Health/HealthCheckServiceTests.cs
@@ -382,6 +382,39 @@ public sealed class HealthCheckServiceTests : IDisposable
         announced.ShouldBeEmpty();
     }
 
+    [Fact]
+    public async Task A_contested_entry_is_dropped_by_the_next_sweep()
+    {
+        Seed(SeedClient("gate"), SeedClient("doomed"));
+
+        HealthCheckService service = BuildService();
+        await service.CheckAllClientsHealthAsync();
+
+        await DeleteClientAsync(Seeded("doomed"));
+
+        (TaskCompletionSource entered, TaskCompletionSource<HealthCheckResult> release) = GateProbeFor("gate");
+
+        List<Guid> announced = [];
+        service.ClientHealthRemoved += (_, e) => announced.Add(e.ClientId);
+
+        Task<IDictionary<Guid, HealthStatus>> sweep = service.CheckAllClientsHealthAsync();
+        await entered.Task;
+
+        // A check racing the delete writes a fresh entry the running sweep must not claim.
+        await service.CheckClientHealthAsync(Seeded("doomed"));
+
+        release.SetResult(new HealthCheckResult { IsHealthy = true });
+        await sweep;
+
+        service.GetClientHealth(Seeded("doomed")).ShouldNotBeNull();
+        announced.ShouldBeEmpty();
+
+        await service.CheckAllClientsHealthAsync();
+
+        service.GetClientHealth(Seeded("doomed")).ShouldBeNull();
+        announced.ShouldBe([Seeded("doomed")]);
+    }
+
     #endregion
 
     #region Single arr instance check

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Health/HealthCheckServiceTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Health/HealthCheckServiceTests.cs
@@ -4,6 +4,7 @@ using Cleanuparr.Infrastructure.Features.DownloadClient;
 using Cleanuparr.Infrastructure.Health;
 using Cleanuparr.Persistence;
 using Cleanuparr.Persistence.Models.Configuration;
+using Cleanuparr.Persistence.Models.Configuration.Arr;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,6 +20,8 @@ public sealed class HealthCheckServiceTests : IDisposable
     private readonly SqliteConnection _connection;
     private readonly DbContextOptions<DataContext> _options;
     private readonly IDownloadServiceFactory _downloadServiceFactory = Substitute.For<IDownloadServiceFactory>();
+    private readonly IInstanceHealthChecker _instanceHealthChecker = Substitute.For<IInstanceHealthChecker>();
+    private readonly Dictionary<string, Guid> _seededIds = new();
 
     public HealthCheckServiceTests()
     {
@@ -32,10 +35,164 @@ public sealed class HealthCheckServiceTests : IDisposable
         using DataContext context = new(_options);
         context.Database.EnsureCreated();
 
-        IDownloadService downloadService = Substitute.For<IDownloadService>();
-        downloadService.HealthCheckAsync().Returns(new HealthCheckResult { IsHealthy = true });
-        _downloadServiceFactory.GetDownloadService(Arg.Any<DownloadClientConfig>()).Returns(downloadService);
+        ProbeReturns(new HealthCheckResult { IsHealthy = true });
     }
+
+    #region Single client check
+
+    [Fact]
+    public async Task A_healthy_client_reports_the_probe_result()
+    {
+        Seed(SeedClient("qbit"));
+        ProbeReturns(new HealthCheckResult { IsHealthy = true, ResponseTime = TimeSpan.FromMilliseconds(42) });
+
+        HealthStatus status = await BuildService().CheckClientHealthAsync(Seeded("qbit"));
+
+        status.IsHealthy.ShouldBeTrue();
+        status.ClientName.ShouldBe("qbit");
+        status.ClientTypeName.ShouldBe(DownloadClientTypeName.qBittorrent);
+        status.ResponseTime.ShouldBe(TimeSpan.FromMilliseconds(42));
+        status.ErrorMessage.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task An_unhealthy_probe_keeps_its_error_message()
+    {
+        Seed(SeedClient("qbit"));
+        ProbeReturns(new HealthCheckResult { IsHealthy = false, ErrorMessage = "401 Unauthorized" });
+
+        HealthStatus status = await BuildService().CheckClientHealthAsync(Seeded("qbit"));
+
+        status.IsHealthy.ShouldBeFalse();
+        status.ErrorMessage.ShouldBe("401 Unauthorized");
+        status.ClientName.ShouldBe("qbit");
+    }
+
+    [Fact]
+    public async Task An_unknown_client_id_reports_unhealthy_and_is_cached()
+    {
+        Guid missing = Guid.NewGuid();
+
+        HealthCheckService service = BuildService();
+        HealthStatus status = await service.CheckClientHealthAsync(missing);
+
+        status.IsHealthy.ShouldBeFalse();
+        status.ErrorMessage.ShouldBe("Client not found in configuration");
+        service.GetClientHealth(missing).ShouldBe(status);
+    }
+
+    [Fact]
+    public async Task A_probe_that_throws_reports_unhealthy_with_the_reason()
+    {
+        Seed(SeedClient("qbit"));
+        ProbeThrows(new InvalidOperationException("connection refused"));
+
+        HealthStatus status = await BuildService().CheckClientHealthAsync(Seeded("qbit"));
+
+        status.IsHealthy.ShouldBeFalse();
+        status.ErrorMessage.ShouldBe("Error: connection refused");
+    }
+
+    #endregion
+
+    #region Client health events
+
+    [Fact]
+    public async Task A_first_unhealthy_check_counts_as_a_degradation()
+    {
+        Seed(SeedClient("qbit"));
+        ProbeReturns(new HealthCheckResult { IsHealthy = false, ErrorMessage = "down" });
+
+        HealthCheckService service = BuildService();
+        List<ClientHealthChangedEventArgs> raised = [];
+        service.ClientHealthChanged += (_, e) => raised.Add(e);
+
+        await service.CheckClientHealthAsync(Seeded("qbit"));
+
+        ClientHealthChangedEventArgs single = raised.ShouldHaveSingleItem();
+        single.IsDegraded.ShouldBeTrue();
+        single.IsRecovered.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task Going_from_healthy_to_unhealthy_raises_a_degradation()
+    {
+        Seed(SeedClient("qbit"));
+
+        HealthCheckService service = BuildService();
+        await service.CheckClientHealthAsync(Seeded("qbit"));
+
+        List<ClientHealthChangedEventArgs> raised = [];
+        service.ClientHealthChanged += (_, e) => raised.Add(e);
+        ProbeReturns(new HealthCheckResult { IsHealthy = false, ErrorMessage = "down" });
+
+        await service.CheckClientHealthAsync(Seeded("qbit"));
+
+        raised.ShouldHaveSingleItem().IsDegraded.ShouldBeTrue();
+    }
+
+    [Fact]
+    public async Task Going_from_unhealthy_to_healthy_raises_a_recovery()
+    {
+        Seed(SeedClient("qbit"));
+        ProbeReturns(new HealthCheckResult { IsHealthy = false, ErrorMessage = "down" });
+
+        HealthCheckService service = BuildService();
+        await service.CheckClientHealthAsync(Seeded("qbit"));
+
+        List<ClientHealthChangedEventArgs> raised = [];
+        service.ClientHealthChanged += (_, e) => raised.Add(e);
+        ProbeReturns(new HealthCheckResult { IsHealthy = true });
+
+        await service.CheckClientHealthAsync(Seeded("qbit"));
+
+        ClientHealthChangedEventArgs single = raised.ShouldHaveSingleItem();
+        single.IsRecovered.ShouldBeTrue();
+        single.IsDegraded.ShouldBeFalse();
+    }
+
+    [Fact]
+    public async Task An_unchanged_state_raises_nothing()
+    {
+        Seed(SeedClient("qbit"));
+
+        HealthCheckService service = BuildService();
+        await service.CheckClientHealthAsync(Seeded("qbit"));
+
+        List<ClientHealthChangedEventArgs> raised = [];
+        service.ClientHealthChanged += (_, e) => raised.Add(e);
+
+        await service.CheckClientHealthAsync(Seeded("qbit"));
+
+        raised.ShouldBeEmpty();
+    }
+
+    #endregion
+
+    #region Reading the cache
+
+    [Fact]
+    public void An_unknown_client_has_no_cached_status()
+    {
+        BuildService().GetClientHealth(Guid.NewGuid()).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task The_returned_map_is_a_copy()
+    {
+        Seed(SeedClient("qbit"));
+
+        HealthCheckService service = BuildService();
+        await service.CheckAllClientsHealthAsync();
+
+        service.GetAllClientHealth().Clear();
+
+        service.GetAllClientHealth().Count.ShouldBe(1);
+    }
+
+    #endregion
+
+    #region Client sweep
 
     [Fact]
     public async Task Checking_all_clients_caches_every_enabled_client()
@@ -49,6 +206,33 @@ public sealed class HealthCheckServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task A_disabled_client_is_never_probed()
+    {
+        DownloadClientConfig disabled = SeedClient("disabled");
+        disabled.Enabled = false;
+        Seed(disabled, SeedClient("enabled"));
+
+        HealthCheckService service = BuildService();
+        IDictionary<Guid, HealthStatus> results = await service.CheckAllClientsHealthAsync();
+
+        results.Keys.ShouldBe([Seeded("enabled")]);
+    }
+
+    [Fact]
+    public async Task One_failing_client_does_not_stop_the_sweep()
+    {
+        Seed(SeedClient("good"), SeedClient("bad"));
+        ProbeThrows(new InvalidOperationException("connection refused"), forClientNamed: "bad");
+
+        HealthCheckService service = BuildService();
+        IDictionary<Guid, HealthStatus> results = await service.CheckAllClientsHealthAsync();
+
+        results.Count.ShouldBe(2);
+        results[Seeded("good")].IsHealthy.ShouldBeTrue();
+        results[Seeded("bad")].IsHealthy.ShouldBeFalse();
+    }
+
+    [Fact]
     public async Task A_deleted_client_stops_being_reported()
     {
         DownloadClientConfig removed = SeedClient("removed");
@@ -57,12 +241,7 @@ public sealed class HealthCheckServiceTests : IDisposable
         HealthCheckService service = BuildService();
         await service.CheckAllClientsHealthAsync();
 
-        await using (DataContext context = new(_options))
-        {
-            context.DownloadClients.Remove(await context.DownloadClients.FirstAsync(c => c.Id == removed.Id));
-            await context.SaveChangesAsync();
-        }
-
+        await DeleteClientAsync(removed.Id);
         await service.CheckAllClientsHealthAsync();
 
         service.GetAllClientHealth().Keys.ShouldBe([Seeded("kept")]);
@@ -102,12 +281,7 @@ public sealed class HealthCheckServiceTests : IDisposable
         List<Guid> announced = [];
         service.ClientHealthRemoved += (_, e) => announced.Add(e.ClientId);
 
-        await using (DataContext context = new(_options))
-        {
-            context.DownloadClients.Remove(await context.DownloadClients.FirstAsync(c => c.Id == removed.Id));
-            await context.SaveChangesAsync();
-        }
-
+        await DeleteClientAsync(removed.Id);
         await service.CheckAllClientsHealthAsync();
 
         announced.ShouldBe([removed.Id]);
@@ -139,14 +313,161 @@ public sealed class HealthCheckServiceTests : IDisposable
 
         // A sweep that cannot read the database returns empty; that is not proof nothing exists.
         _connection.Close();
-        await service.CheckAllClientsHealthAsync();
+        IDictionary<Guid, HealthStatus> results = await service.CheckAllClientsHealthAsync();
 
+        results.ShouldBeEmpty();
         service.GetAllClientHealth().Count.ShouldBe(1);
     }
 
-    private readonly Dictionary<string, Guid> _seededIds = new();
+    #endregion
+
+    #region Single arr instance check
+
+    [Fact]
+    public async Task A_reachable_arr_instance_reports_healthy()
+    {
+        SeedArr(InstanceType.Sonarr, "main", enabled: true);
+
+        ArrHealthStatus status = await BuildService().CheckArrInstanceHealthAsync(Seeded("main"));
+
+        status.IsHealthy.ShouldBeTrue();
+        status.InstanceName.ShouldBe("main");
+        status.InstanceType.ShouldBe(InstanceType.Sonarr);
+        status.ErrorMessage.ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task An_unknown_arr_instance_id_reports_unhealthy_and_is_cached()
+    {
+        Guid missing = Guid.NewGuid();
+
+        HealthCheckService service = BuildService();
+        ArrHealthStatus status = await service.CheckArrInstanceHealthAsync(missing);
+
+        status.IsHealthy.ShouldBeFalse();
+        status.ErrorMessage.ShouldBe("Arr instance not found in configuration");
+        service.GetArrInstanceHealth(missing).ShouldBe(status);
+    }
+
+    [Fact]
+    public async Task An_arr_probe_that_throws_reports_unhealthy_with_the_reason()
+    {
+        SeedArr(InstanceType.Radarr, "main", enabled: true);
+        ArrProbeThrows(new InvalidOperationException("api key rejected"));
+
+        ArrHealthStatus status = await BuildService().CheckArrInstanceHealthAsync(Seeded("main"));
+
+        status.IsHealthy.ShouldBeFalse();
+        status.ErrorMessage.ShouldBe("Error: api key rejected");
+    }
+
+    #endregion
+
+    #region Arr sweep
+
+    [Fact]
+    public async Task A_disabled_arr_instance_is_never_probed()
+    {
+        SeedArr(InstanceType.Sonarr, "enabled", enabled: true);
+        SeedArr(InstanceType.Radarr, "disabled", enabled: false);
+
+        IDictionary<Guid, ArrHealthStatus> results = await BuildService().CheckAllArrInstancesHealthAsync();
+
+        results.Keys.ShouldBe([Seeded("enabled")]);
+    }
+
+    [Fact]
+    public async Task One_failing_arr_instance_does_not_stop_the_sweep()
+    {
+        SeedArr(InstanceType.Sonarr, "good", enabled: true);
+        SeedArr(InstanceType.Radarr, "bad", enabled: true);
+        ArrProbeThrows(new InvalidOperationException("unreachable"), forInstanceNamed: "bad");
+
+        IDictionary<Guid, ArrHealthStatus> results = await BuildService().CheckAllArrInstancesHealthAsync();
+
+        results.Count.ShouldBe(2);
+        results[Seeded("good")].IsHealthy.ShouldBeTrue();
+        results[Seeded("bad")].IsHealthy.ShouldBeFalse();
+        results[Seeded("bad")].ErrorMessage.ShouldBe("Error: unreachable");
+    }
+
+    [Fact]
+    public async Task A_deleted_arr_instance_stops_being_reported()
+    {
+        SeedArr(InstanceType.Sonarr, "removed", enabled: true);
+        SeedArr(InstanceType.Radarr, "kept", enabled: true);
+
+        HealthCheckService service = BuildService();
+        await service.CheckAllArrInstancesHealthAsync();
+
+        Guid removedId = Seeded("removed");
+        await using (DataContext context = new(_options))
+        {
+            ArrConfig config = await context.ArrConfigs
+                .Include(c => c.Instances)
+                .FirstAsync(c => c.Instances.Any(i => i.Id == removedId));
+            config.Instances.Remove(config.Instances.First(i => i.Id == removedId));
+            await context.SaveChangesAsync();
+        }
+
+        await service.CheckAllArrInstancesHealthAsync();
+
+        service.GetAllArrInstanceHealth().Keys.ShouldBe([Seeded("kept")]);
+        service.GetArrInstanceHealth(removedId).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task A_failed_arr_sweep_keeps_what_was_already_cached()
+    {
+        SeedArr(InstanceType.Sonarr, "main", enabled: true);
+
+        HealthCheckService service = BuildService();
+        await service.CheckAllArrInstancesHealthAsync();
+
+        _connection.Close();
+        IDictionary<Guid, ArrHealthStatus> results = await service.CheckAllArrInstancesHealthAsync();
+
+        results.ShouldBeEmpty();
+        service.GetAllArrInstanceHealth().Count.ShouldBe(1);
+    }
+
+    #endregion
 
     private Guid Seeded(string name) => _seededIds[name];
+
+    private void ProbeReturns(HealthCheckResult result, string? forClientNamed = null)
+    {
+        IDownloadService downloadService = Substitute.For<IDownloadService>();
+        downloadService.HealthCheckAsync().Returns(result);
+        RegisterDownloadService(downloadService, forClientNamed);
+    }
+
+    private void ProbeThrows(Exception exception, string? forClientNamed = null)
+    {
+        IDownloadService downloadService = Substitute.For<IDownloadService>();
+        downloadService.HealthCheckAsync().Returns(Task.FromException<HealthCheckResult>(exception));
+        RegisterDownloadService(downloadService, forClientNamed);
+    }
+
+    private void RegisterDownloadService(IDownloadService downloadService, string? forClientNamed)
+    {
+        _downloadServiceFactory
+            .GetDownloadService(forClientNamed is null
+                ? Arg.Any<DownloadClientConfig>()
+                : Arg.Is<DownloadClientConfig>(c => c.Name == forClientNamed))
+            .Returns(downloadService);
+    }
+
+    private void ArrProbeThrows(Exception exception, string? forInstanceNamed = null)
+    {
+        _instanceHealthChecker
+            .CheckAsync(
+                Arg.Any<InstanceType>(),
+                forInstanceNamed is null
+                    ? Arg.Any<ArrInstance>()
+                    : Arg.Is<ArrInstance>(i => i.Name == forInstanceNamed))
+            .Returns(Task.FromException(exception));
+    }
 
     private DownloadClientConfig SeedClient(string name)
     {
@@ -172,11 +493,37 @@ public sealed class HealthCheckServiceTests : IDisposable
         context.SaveChanges();
     }
 
+    private void SeedArr(InstanceType type, string instanceName, bool enabled)
+    {
+        ArrInstance instance = new()
+        {
+            Id = Guid.NewGuid(),
+            Enabled = enabled,
+            Name = instanceName,
+            Url = new Uri("http://localhost:8989"),
+            ApiKey = "key",
+        };
+
+        _seededIds[instanceName] = instance.Id;
+
+        using DataContext context = new(_options);
+        context.ArrConfigs.Add(new ArrConfig { Id = Guid.NewGuid(), Type = type, Instances = [instance] });
+        context.SaveChanges();
+    }
+
+    private async Task DeleteClientAsync(Guid clientId)
+    {
+        await using DataContext context = new(_options);
+        context.DownloadClients.Remove(await context.DownloadClients.FirstAsync(c => c.Id == clientId));
+        await context.SaveChangesAsync();
+    }
+
     private HealthCheckService BuildService()
     {
         ServiceCollection services = new();
         services.AddScoped(_ => new DataContext(_options));
         services.AddScoped(_ => _downloadServiceFactory);
+        services.AddScoped(_ => _instanceHealthChecker);
 
         return new HealthCheckService(
             NullLogger<HealthCheckService>.Instance,

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Health/HealthCheckServiceTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Health/HealthCheckServiceTests.cs
@@ -1,0 +1,151 @@
+using Cleanuparr.Domain.Entities.HealthCheck;
+using Cleanuparr.Domain.Enums;
+using Cleanuparr.Infrastructure.Features.DownloadClient;
+using Cleanuparr.Infrastructure.Health;
+using Cleanuparr.Persistence;
+using Cleanuparr.Persistence.Models.Configuration;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Cleanuparr.Infrastructure.Tests.Health;
+
+public sealed class HealthCheckServiceTests : IDisposable
+{
+    private readonly SqliteConnection _connection;
+    private readonly DbContextOptions<DataContext> _options;
+    private readonly IDownloadServiceFactory _downloadServiceFactory = Substitute.For<IDownloadServiceFactory>();
+
+    public HealthCheckServiceTests()
+    {
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _options = new DbContextOptionsBuilder<DataContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        using DataContext context = new(_options);
+        context.Database.EnsureCreated();
+
+        IDownloadService downloadService = Substitute.For<IDownloadService>();
+        downloadService.HealthCheckAsync().Returns(new HealthCheckResult { IsHealthy = true });
+        _downloadServiceFactory.GetDownloadService(Arg.Any<DownloadClientConfig>()).Returns(downloadService);
+    }
+
+    [Fact]
+    public async Task Checking_all_clients_caches_every_enabled_client()
+    {
+        Seed(SeedClient("first"), SeedClient("second"));
+
+        HealthCheckService service = BuildService();
+        await service.CheckAllClientsHealthAsync();
+
+        service.GetAllClientHealth().Count.ShouldBe(2);
+    }
+
+    [Fact]
+    public async Task A_deleted_client_stops_being_reported()
+    {
+        DownloadClientConfig removed = SeedClient("removed");
+        Seed(removed, SeedClient("kept"));
+
+        HealthCheckService service = BuildService();
+        await service.CheckAllClientsHealthAsync();
+
+        await using (DataContext context = new(_options))
+        {
+            context.DownloadClients.Remove(await context.DownloadClients.FirstAsync(c => c.Id == removed.Id));
+            await context.SaveChangesAsync();
+        }
+
+        await service.CheckAllClientsHealthAsync();
+
+        service.GetAllClientHealth().Keys.ShouldBe([Seeded("kept")]);
+        service.GetClientHealth(removed.Id).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task A_disabled_client_stops_being_reported()
+    {
+        DownloadClientConfig disabled = SeedClient("disabled");
+        Seed(disabled, SeedClient("kept"));
+
+        HealthCheckService service = BuildService();
+        await service.CheckAllClientsHealthAsync();
+
+        await using (DataContext context = new(_options))
+        {
+            DownloadClientConfig stored = await context.DownloadClients.FirstAsync(c => c.Id == disabled.Id);
+            stored.Enabled = false;
+            await context.SaveChangesAsync();
+        }
+
+        await service.CheckAllClientsHealthAsync();
+
+        service.GetAllClientHealth().Keys.ShouldBe([Seeded("kept")]);
+    }
+
+    [Fact]
+    public async Task A_failed_sweep_keeps_what_was_already_cached()
+    {
+        Seed(SeedClient("first"));
+
+        HealthCheckService service = BuildService();
+        await service.CheckAllClientsHealthAsync();
+
+        // A sweep that cannot read the database returns empty; that is not proof nothing exists.
+        _connection.Close();
+        await service.CheckAllClientsHealthAsync();
+
+        service.GetAllClientHealth().Count.ShouldBe(1);
+    }
+
+    private readonly Dictionary<string, Guid> _seededIds = new();
+
+    private Guid Seeded(string name) => _seededIds[name];
+
+    private DownloadClientConfig SeedClient(string name)
+    {
+        DownloadClientConfig client = new()
+        {
+            Id = Guid.NewGuid(),
+            Enabled = true,
+            Name = name,
+            TypeName = DownloadClientTypeName.qBittorrent,
+            Type = DownloadClientType.Torrent,
+            Host = new Uri("http://localhost:8080"),
+        };
+
+        _seededIds[name] = client.Id;
+
+        return client;
+    }
+
+    private void Seed(params DownloadClientConfig[] clients)
+    {
+        using DataContext context = new(_options);
+        context.DownloadClients.AddRange(clients);
+        context.SaveChanges();
+    }
+
+    private HealthCheckService BuildService()
+    {
+        ServiceCollection services = new();
+        services.AddScoped(_ => new DataContext(_options));
+        services.AddScoped(_ => _downloadServiceFactory);
+
+        return new HealthCheckService(
+            NullLogger<HealthCheckService>.Instance,
+            services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>());
+    }
+
+    public void Dispose()
+    {
+        _connection.Dispose();
+    }
+}

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Health/HealthCheckServiceTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Health/HealthCheckServiceTests.cs
@@ -352,6 +352,36 @@ public sealed class HealthCheckServiceTests : IDisposable
         service.GetClientHealth(late.Id).ShouldNotBeNull();
     }
 
+    [Fact]
+    public async Task A_sweep_in_flight_does_not_drop_a_client_rechecked_after_it_started()
+    {
+        Seed(SeedClient("gate"), SeedClient("flipped"));
+
+        HealthCheckService service = BuildService();
+        await service.CheckAllClientsHealthAsync();
+
+        // Disabled before the sweep reads the configuration, so the sweep will not cover it.
+        await SetClientEnabledAsync(Seeded("flipped"), enabled: false);
+
+        (TaskCompletionSource entered, TaskCompletionSource<HealthCheckResult> release) = GateProbeFor("gate");
+
+        List<Guid> announced = [];
+        service.ClientHealthRemoved += (_, e) => announced.Add(e.ClientId);
+
+        Task<IDictionary<Guid, HealthStatus>> sweep = service.CheckAllClientsHealthAsync();
+        await entered.Task;
+
+        // Re-enabled and rechecked while the sweep is still parked on the other probe.
+        await SetClientEnabledAsync(Seeded("flipped"), enabled: true);
+        await service.CheckClientHealthAsync(Seeded("flipped"));
+
+        release.SetResult(new HealthCheckResult { IsHealthy = true });
+        await sweep;
+
+        service.GetClientHealth(Seeded("flipped")).ShouldNotBeNull();
+        announced.ShouldBeEmpty();
+    }
+
     #endregion
 
     #region Single arr instance check
@@ -477,6 +507,43 @@ public sealed class HealthCheckServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task A_sweep_in_flight_does_not_drop_an_arr_instance_rechecked_after_it_started()
+    {
+        SeedArr(InstanceType.Sonarr, "gate", enabled: true);
+        SeedArr(InstanceType.Radarr, "flipped", enabled: true);
+
+        HealthCheckService service = BuildService();
+        await service.CheckAllArrInstancesHealthAsync();
+
+        await SetArrInstanceEnabledAsync(Seeded("flipped"), enabled: false);
+
+        TaskCompletionSource entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        _instanceHealthChecker
+            .CheckAsync(Arg.Any<InstanceType>(), Arg.Is<ArrInstance>(i => i.Name == "gate"))
+            .Returns(_ =>
+            {
+                entered.TrySetResult();
+                return release.Task;
+            });
+
+        List<Guid> announced = [];
+        service.ArrInstanceHealthRemoved += (_, e) => announced.Add(e.InstanceId);
+
+        Task<IDictionary<Guid, ArrHealthStatus>> sweep = service.CheckAllArrInstancesHealthAsync();
+        await entered.Task;
+
+        await SetArrInstanceEnabledAsync(Seeded("flipped"), enabled: true);
+        await service.CheckArrInstanceHealthAsync(Seeded("flipped"));
+
+        release.SetResult();
+        await sweep;
+
+        service.GetArrInstanceHealth(Seeded("flipped")).ShouldNotBeNull();
+        announced.ShouldBeEmpty();
+    }
+
+    [Fact]
     public async Task A_failed_arr_sweep_keeps_what_was_already_cached()
     {
         SeedArr(InstanceType.Sonarr, "main", enabled: true);
@@ -527,6 +594,40 @@ public sealed class HealthCheckServiceTests : IDisposable
                     ? Arg.Any<ArrInstance>()
                     : Arg.Is<ArrInstance>(i => i.Name == forInstanceNamed))
             .Returns(Task.FromException(exception));
+    }
+
+    private (TaskCompletionSource Entered, TaskCompletionSource<HealthCheckResult> Release) GateProbeFor(string clientName)
+    {
+        TaskCompletionSource entered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource<HealthCheckResult> release = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        IDownloadService gated = Substitute.For<IDownloadService>();
+        gated.HealthCheckAsync().Returns(_ =>
+        {
+            entered.TrySetResult();
+            return release.Task;
+        });
+        RegisterDownloadService(gated, clientName);
+
+        return (entered, release);
+    }
+
+    private async Task SetClientEnabledAsync(Guid clientId, bool enabled)
+    {
+        await using DataContext context = new(_options);
+        DownloadClientConfig stored = await context.DownloadClients.FirstAsync(c => c.Id == clientId);
+        stored.Enabled = enabled;
+        await context.SaveChangesAsync();
+    }
+
+    private async Task SetArrInstanceEnabledAsync(Guid instanceId, bool enabled)
+    {
+        await using DataContext context = new(_options);
+        ArrConfig config = await context.ArrConfigs
+            .Include(c => c.Instances)
+            .FirstAsync(c => c.Instances.Any(i => i.Id == instanceId));
+        config.Instances.First(i => i.Id == instanceId).Enabled = enabled;
+        await context.SaveChangesAsync();
     }
 
     private DownloadClientConfig SeedClient(string name)

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Health/HealthCheckServiceTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Health/HealthCheckServiceTests.cs
@@ -319,6 +319,39 @@ public sealed class HealthCheckServiceTests : IDisposable
         service.GetAllClientHealth().Count.ShouldBe(1);
     }
 
+    [Fact]
+    public async Task A_sweep_in_flight_does_not_drop_a_client_checked_after_it_started()
+    {
+        Seed(SeedClient("slow"));
+
+        TaskCompletionSource probeEntered = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource<HealthCheckResult> releaseProbe = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        IDownloadService slowService = Substitute.For<IDownloadService>();
+        slowService.HealthCheckAsync().Returns(_ =>
+        {
+            probeEntered.TrySetResult();
+            return releaseProbe.Task;
+        });
+        _downloadServiceFactory
+            .GetDownloadService(Arg.Is<DownloadClientConfig>(c => c.Name == "slow"))
+            .Returns(slowService);
+
+        HealthCheckService service = BuildService();
+        Task<IDictionary<Guid, HealthStatus>> sweep = service.CheckAllClientsHealthAsync();
+        await probeEntered.Task;
+
+        // A client enabled after the sweep took its snapshot, checked while the sweep is still running.
+        DownloadClientConfig late = SeedClient("late");
+        Seed(late);
+        await service.CheckClientHealthAsync(late.Id);
+
+        releaseProbe.SetResult(new HealthCheckResult { IsHealthy = true });
+        await sweep;
+
+        service.GetClientHealth(late.Id).ShouldNotBeNull();
+    }
+
     #endregion
 
     #region Single arr instance check
@@ -414,6 +447,33 @@ public sealed class HealthCheckServiceTests : IDisposable
 
         service.GetAllArrInstanceHealth().Keys.ShouldBe([Seeded("kept")]);
         service.GetArrInstanceHealth(removedId).ShouldBeNull();
+    }
+
+    [Fact]
+    public async Task Dropping_an_arr_instance_announces_the_removal()
+    {
+        SeedArr(InstanceType.Sonarr, "removed", enabled: true);
+        SeedArr(InstanceType.Radarr, "kept", enabled: true);
+
+        HealthCheckService service = BuildService();
+        await service.CheckAllArrInstancesHealthAsync();
+
+        List<Guid> announced = [];
+        service.ArrInstanceHealthRemoved += (_, e) => announced.Add(e.InstanceId);
+
+        Guid removedId = Seeded("removed");
+        await using (DataContext context = new(_options))
+        {
+            ArrConfig config = await context.ArrConfigs
+                .Include(c => c.Instances)
+                .FirstAsync(c => c.Instances.Any(i => i.Id == removedId));
+            config.Instances.Remove(config.Instances.First(i => i.Id == removedId));
+            await context.SaveChangesAsync();
+        }
+
+        await service.CheckAllArrInstancesHealthAsync();
+
+        announced.ShouldBe([removedId]);
     }
 
     [Fact]

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Health/HealthCheckServiceTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Health/HealthCheckServiceTests.cs
@@ -91,6 +91,45 @@ public sealed class HealthCheckServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task Dropping_a_client_announces_the_removal()
+    {
+        DownloadClientConfig removed = SeedClient("removed");
+        Seed(removed, SeedClient("kept"));
+
+        HealthCheckService service = BuildService();
+        await service.CheckAllClientsHealthAsync();
+
+        List<Guid> announced = [];
+        service.ClientHealthRemoved += (_, e) => announced.Add(e.ClientId);
+
+        await using (DataContext context = new(_options))
+        {
+            context.DownloadClients.Remove(await context.DownloadClients.FirstAsync(c => c.Id == removed.Id));
+            await context.SaveChangesAsync();
+        }
+
+        await service.CheckAllClientsHealthAsync();
+
+        announced.ShouldBe([removed.Id]);
+    }
+
+    [Fact]
+    public async Task A_sweep_that_drops_nothing_announces_nothing()
+    {
+        Seed(SeedClient("kept"));
+
+        HealthCheckService service = BuildService();
+        await service.CheckAllClientsHealthAsync();
+
+        List<Guid> announced = [];
+        service.ClientHealthRemoved += (_, e) => announced.Add(e.ClientId);
+
+        await service.CheckAllClientsHealthAsync();
+
+        announced.ShouldBeEmpty();
+    }
+
+    [Fact]
     public async Task A_failed_sweep_keeps_what_was_already_cached()
     {
         Seed(SeedClient("first"));

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Health/HealthStatusBroadcasterTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Health/HealthStatusBroadcasterTests.cs
@@ -1,0 +1,59 @@
+using Cleanuparr.Infrastructure.Health;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Shouldly;
+using Xunit;
+
+namespace Cleanuparr.Infrastructure.Tests.Health;
+
+public sealed class HealthStatusBroadcasterTests
+{
+    private readonly IHealthCheckService _healthCheckService = Substitute.For<IHealthCheckService>();
+    private readonly IHubContext<HealthStatusHub> _hubContext = Substitute.For<IHubContext<HealthStatusHub>>();
+    private readonly IClientProxy _allClients = Substitute.For<IClientProxy>();
+
+    public HealthStatusBroadcasterTests()
+    {
+        IHubClients clients = Substitute.For<IHubClients>();
+        clients.All.Returns(_allClients);
+        _hubContext.Clients.Returns(clients);
+        _allClients
+            .SendCoreAsync(Arg.Any<string>(), Arg.Any<object?[]>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask);
+    }
+
+    [Fact]
+    public async Task A_dropped_client_is_broadcast_to_every_connection()
+    {
+        Guid clientId = Guid.NewGuid();
+
+        HealthStatusBroadcaster broadcaster = BuildBroadcaster();
+        await broadcaster.StartAsync(CancellationToken.None);
+
+        _healthCheckService.ClientHealthRemoved += Raise.EventWith(new ClientHealthRemovedEventArgs(clientId));
+
+        await _allClients.Received(1).SendCoreAsync(
+            "ClientRemoved",
+            Arg.Is<object?[]>(args => args.Length == 1 && Equals(args[0], clientId)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Stopping_unsubscribes_from_removals()
+    {
+        HealthStatusBroadcaster broadcaster = BuildBroadcaster();
+        await broadcaster.StartAsync(CancellationToken.None);
+        await broadcaster.StopAsync(CancellationToken.None);
+
+        _healthCheckService.ClientHealthRemoved += Raise.EventWith(new ClientHealthRemovedEventArgs(Guid.NewGuid()));
+
+        await _allClients.DidNotReceive().SendCoreAsync(
+            "ClientRemoved",
+            Arg.Any<object?[]>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    private HealthStatusBroadcaster BuildBroadcaster() =>
+        new(NullLogger<HealthStatusBroadcaster>.Instance, _healthCheckService, _hubContext);
+}

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Health/HealthStatusBroadcasterTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Health/HealthStatusBroadcasterTests.cs
@@ -54,6 +54,37 @@ public sealed class HealthStatusBroadcasterTests
             Arg.Any<CancellationToken>());
     }
 
+    [Fact]
+    public async Task A_dropped_arr_instance_is_broadcast_to_every_connection()
+    {
+        Guid instanceId = Guid.NewGuid();
+
+        HealthStatusBroadcaster broadcaster = BuildBroadcaster();
+        await broadcaster.StartAsync(CancellationToken.None);
+
+        _healthCheckService.ArrInstanceHealthRemoved += Raise.EventWith(new ArrInstanceHealthRemovedEventArgs(instanceId));
+
+        await _allClients.Received(1).SendCoreAsync(
+            "ArrInstanceRemoved",
+            Arg.Is<object?[]>(args => args.Length == 1 && Equals(args[0], instanceId)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Stopping_unsubscribes_from_arr_removals()
+    {
+        HealthStatusBroadcaster broadcaster = BuildBroadcaster();
+        await broadcaster.StartAsync(CancellationToken.None);
+        await broadcaster.StopAsync(CancellationToken.None);
+
+        _healthCheckService.ArrInstanceHealthRemoved += Raise.EventWith(new ArrInstanceHealthRemovedEventArgs(Guid.NewGuid()));
+
+        await _allClients.DidNotReceive().SendCoreAsync(
+            "ArrInstanceRemoved",
+            Arg.Any<object?[]>(),
+            Arg.Any<CancellationToken>());
+    }
+
     private HealthStatusBroadcaster BuildBroadcaster() =>
         new(NullLogger<HealthStatusBroadcaster>.Instance, _healthCheckService, _hubContext);
 }

--- a/code/backend/Cleanuparr.Infrastructure/Health/ArrInstanceHealthRemovedEventArgs.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/ArrInstanceHealthRemovedEventArgs.cs
@@ -1,0 +1,21 @@
+namespace Cleanuparr.Infrastructure.Health;
+
+/// <summary>
+/// Event arguments for an arr instance dropped from the health cache
+/// </summary>
+public class ArrInstanceHealthRemovedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the arr instance ID
+    /// </summary>
+    public Guid InstanceId { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArrInstanceHealthRemovedEventArgs"/> class
+    /// </summary>
+    /// <param name="instanceId">The arr instance ID</param>
+    public ArrInstanceHealthRemovedEventArgs(Guid instanceId)
+    {
+        InstanceId = instanceId;
+    }
+}

--- a/code/backend/Cleanuparr.Infrastructure/Health/ClientHealthRemovedEventArgs.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/ClientHealthRemovedEventArgs.cs
@@ -1,0 +1,21 @@
+namespace Cleanuparr.Infrastructure.Health;
+
+/// <summary>
+/// Event arguments for a client dropped from the health cache
+/// </summary>
+public class ClientHealthRemovedEventArgs : EventArgs
+{
+    /// <summary>
+    /// Gets the client ID
+    /// </summary>
+    public Guid ClientId { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClientHealthRemovedEventArgs"/> class
+    /// </summary>
+    /// <param name="clientId">The client ID</param>
+    public ClientHealthRemovedEventArgs(Guid clientId)
+    {
+        ClientId = clientId;
+    }
+}

--- a/code/backend/Cleanuparr.Infrastructure/Health/HealthCheckService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/HealthCheckService.cs
@@ -331,9 +331,6 @@ public class HealthCheckService : IHealthCheckService
         }
     }
 
-    /// <summary>
-    /// Drops cached clients that have been invalidated.
-    /// </summary>
     private Dictionary<Guid, HealthStatus> SnapshotClients()
     {
         lock (_lockObject)

--- a/code/backend/Cleanuparr.Infrastructure/Health/HealthCheckService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/HealthCheckService.cs
@@ -23,6 +23,11 @@ public class HealthCheckService : IHealthCheckService
     /// </summary>
     public event EventHandler<ClientHealthChangedEventArgs>? ClientHealthChanged;
 
+    /// <summary>
+    /// Occurs when a client is no longer covered by the health sweep
+    /// </summary>
+    public event EventHandler<ClientHealthRemovedEventArgs>? ClientHealthRemoved;
+
     public HealthCheckService(
         ILogger<HealthCheckService> logger,
         IServiceScopeFactory scopeFactory
@@ -321,13 +326,21 @@ public class HealthCheckService : IHealthCheckService
     private void PruneClientHealthStatuses(IEnumerable<Guid> checkedClientIds)
     {
         HashSet<Guid> live = checkedClientIds.ToHashSet();
+        List<Guid> removed = [];
 
         lock (_lockObject)
         {
             foreach (Guid stale in _healthStatuses.Keys.Where(id => !live.Contains(id)).ToList())
             {
                 _healthStatuses.Remove(stale);
+                removed.Add(stale);
             }
+        }
+
+        foreach (Guid clientId in removed)
+        {
+            _logger.LogDebug("Client {clientId} dropped from the health cache", clientId);
+            ClientHealthRemoved?.Invoke(this, new ClientHealthRemovedEventArgs(clientId));
         }
     }
 

--- a/code/backend/Cleanuparr.Infrastructure/Health/HealthCheckService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/HealthCheckService.cs
@@ -28,6 +28,11 @@ public class HealthCheckService : IHealthCheckService
     /// </summary>
     public event EventHandler<ClientHealthRemovedEventArgs>? ClientHealthRemoved;
 
+    /// <summary>
+    /// Occurs when an arr instance is no longer covered by the health sweep
+    /// </summary>
+    public event EventHandler<ArrInstanceHealthRemovedEventArgs>? ArrInstanceHealthRemoved;
+
     public HealthCheckService(
         ILogger<HealthCheckService> logger,
         IServiceScopeFactory scopeFactory
@@ -110,7 +115,10 @@ public class HealthCheckService : IHealthCheckService
     public async Task<IDictionary<Guid, HealthStatus>> CheckAllClientsHealthAsync()
     {
         _logger.LogDebug("Checking health for all enabled clients");
-        
+
+        // Captured before anything is awaited: an entry written later belongs to a newer check.
+        HashSet<Guid> knownAtStart = SnapshotClientIds();
+
         try
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
@@ -129,7 +137,7 @@ public class HealthCheckService : IHealthCheckService
                 results[clientConfig.Id] = status;
             }
             
-            PruneClientHealthStatuses(results.Keys);
+            PruneClientHealthStatuses(results.Keys, knownAtStart);
             
             return results;
         }
@@ -233,6 +241,9 @@ public class HealthCheckService : IHealthCheckService
     {
         _logger.LogDebug("Checking health for all enabled arr instances");
 
+        // Captured before anything is awaited: an entry written later belongs to a newer check.
+        HashSet<Guid> knownAtStart = SnapshotArrInstanceIds();
+
         try
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
@@ -291,7 +302,7 @@ public class HealthCheckService : IHealthCheckService
                 }
             }
 
-            PruneArrHealthStatuses(results.Keys);
+            PruneArrHealthStatuses(results.Keys, knownAtStart);
 
             return results;
         }
@@ -323,14 +334,30 @@ public class HealthCheckService : IHealthCheckService
     /// <summary>
     /// Drops cached clients that have been invalidated.
     /// </summary>
-    private void PruneClientHealthStatuses(IEnumerable<Guid> checkedClientIds)
+    private HashSet<Guid> SnapshotClientIds()
+    {
+        lock (_lockObject)
+        {
+            return _healthStatuses.Keys.ToHashSet();
+        }
+    }
+
+    private HashSet<Guid> SnapshotArrInstanceIds()
+    {
+        lock (_lockObject)
+        {
+            return _arrHealthStatuses.Keys.ToHashSet();
+        }
+    }
+
+    private void PruneClientHealthStatuses(IEnumerable<Guid> checkedClientIds, HashSet<Guid> knownAtStart)
     {
         HashSet<Guid> live = checkedClientIds.ToHashSet();
         List<Guid> removed = [];
 
         lock (_lockObject)
         {
-            foreach (Guid stale in _healthStatuses.Keys.Where(id => !live.Contains(id)).ToList())
+            foreach (Guid stale in knownAtStart.Where(id => !live.Contains(id)).ToList())
             {
                 _healthStatuses.Remove(stale);
                 removed.Add(stale);
@@ -347,16 +374,24 @@ public class HealthCheckService : IHealthCheckService
     /// <summary>
     /// Drops cached arr instances that have been invalidated.
     /// </summary>
-    private void PruneArrHealthStatuses(IEnumerable<Guid> checkedInstanceIds)
+    private void PruneArrHealthStatuses(IEnumerable<Guid> checkedInstanceIds, HashSet<Guid> knownAtStart)
     {
         HashSet<Guid> live = checkedInstanceIds.ToHashSet();
+        List<Guid> removed = [];
 
         lock (_lockObject)
         {
-            foreach (Guid stale in _arrHealthStatuses.Keys.Where(id => !live.Contains(id)).ToList())
+            foreach (Guid stale in knownAtStart.Where(id => !live.Contains(id)).ToList())
             {
                 _arrHealthStatuses.Remove(stale);
+                removed.Add(stale);
             }
+        }
+
+        foreach (Guid instanceId in removed)
+        {
+            _logger.LogDebug("Arr instance {instanceId} dropped from the health cache", instanceId);
+            ArrInstanceHealthRemoved?.Invoke(this, new ArrInstanceHealthRemovedEventArgs(instanceId));
         }
     }
 

--- a/code/backend/Cleanuparr.Infrastructure/Health/HealthCheckService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/HealthCheckService.cs
@@ -45,7 +45,7 @@ public class HealthCheckService : IHealthCheckService
     /// <inheritdoc />
     public async Task<HealthStatus> CheckClientHealthAsync(Guid clientId)
     {
-        _logger.LogDebug("Checking health for client {clientId}", clientId);
+        _logger.LogDebug("Checking health for client {ClientId}", clientId);
 
         try
         {
@@ -59,7 +59,7 @@ public class HealthCheckService : IHealthCheckService
             
             if (downloadClientConfig is null)
             {
-                _logger.LogWarning("Client {clientId} not found in configuration", clientId);
+                _logger.LogWarning("Client {ClientId} not found in configuration", clientId);
                 var notFoundStatus = new HealthStatus
                 {
                     ClientId = clientId,
@@ -96,7 +96,7 @@ public class HealthCheckService : IHealthCheckService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error performing health check for client {clientId}", clientId);
+            _logger.LogError(ex, "Error performing health check for client {ClientId}", clientId);
             
             var status = new HealthStatus
             {
@@ -169,7 +169,7 @@ public class HealthCheckService : IHealthCheckService
     /// <inheritdoc />
     public async Task<ArrHealthStatus> CheckArrInstanceHealthAsync(Guid instanceId)
     {
-        _logger.LogDebug("Checking health for arr instance {instanceId}", instanceId);
+        _logger.LogDebug("Checking health for arr instance {InstanceId}", instanceId);
 
         try
         {
@@ -190,7 +190,7 @@ public class HealthCheckService : IHealthCheckService
 
             if (arrInstance is null)
             {
-                _logger.LogWarning("Arr instance {instanceId} not found in configuration", instanceId);
+                _logger.LogWarning("Arr instance {InstanceId} not found in configuration", instanceId);
                 var notFoundStatus = new ArrHealthStatus
                 {
                     InstanceId = instanceId,
@@ -221,7 +221,7 @@ public class HealthCheckService : IHealthCheckService
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error performing health check for arr instance {instanceId}", instanceId);
+            _logger.LogError(ex, "Error performing health check for arr instance {InstanceId}", instanceId);
 
             var status = new ArrHealthStatus
             {
@@ -284,7 +284,7 @@ public class HealthCheckService : IHealthCheckService
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError(ex, "Error performing health check for arr instance {instanceId} ({instanceName})",
+                    _logger.LogError(ex, "Error performing health check for arr instance {InstanceId} ({InstanceName})",
                         entry.Instance.Id, entry.Instance.Name);
 
                     var status = new ArrHealthStatus
@@ -366,7 +366,7 @@ public class HealthCheckService : IHealthCheckService
 
         foreach (Guid clientId in removed)
         {
-            _logger.LogDebug("Client {clientId} dropped from the health cache", clientId);
+            _logger.LogDebug("Client {ClientId} dropped from the health cache", clientId);
             ClientHealthRemoved?.Invoke(this, new ClientHealthRemovedEventArgs(clientId));
         }
     }
@@ -390,7 +390,7 @@ public class HealthCheckService : IHealthCheckService
 
         foreach (Guid instanceId in removed)
         {
-            _logger.LogDebug("Arr instance {instanceId} dropped from the health cache", instanceId);
+            _logger.LogDebug("Arr instance {InstanceId} dropped from the health cache", instanceId);
             ArrInstanceHealthRemoved?.Invoke(this, new ArrInstanceHealthRemovedEventArgs(instanceId));
         }
     }
@@ -411,7 +411,7 @@ public class HealthCheckService : IHealthCheckService
         if (isStateChange)
         {
             _logger.LogInformation(
-                "Arr instance {instanceId} ({instanceName}) health changed: {status}",
+                "Arr instance {InstanceId} ({InstanceName}) health changed: {Status}",
                 newStatus.InstanceId,
                 newStatus.InstanceName,
                 newStatus.IsHealthy ? "Healthy" : "Unhealthy");
@@ -439,7 +439,7 @@ public class HealthCheckService : IHealthCheckService
         if (isStateChange)
         {
             _logger.LogInformation(
-                "Client {clientId} health changed: {status}", 
+                "Client {ClientId} health changed: {Status}", 
                 newStatus.ClientId, 
                 newStatus.IsHealthy ? "Healthy" : "Unhealthy");
             

--- a/code/backend/Cleanuparr.Infrastructure/Health/HealthCheckService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/HealthCheckService.cs
@@ -1,4 +1,4 @@
-﻿using Cleanuparr.Infrastructure.Features.Arr.Interfaces;
+using Cleanuparr.Infrastructure.Features.Arr.Interfaces;
 using Cleanuparr.Infrastructure.Features.DownloadClient;
 using Cleanuparr.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -123,6 +123,8 @@ public class HealthCheckService : IHealthCheckService
                 var status = await CheckClientHealthAsync(clientConfig.Id);
                 results[clientConfig.Id] = status;
             }
+            
+            PruneClientHealthStatuses(results.Keys);
             
             return results;
         }
@@ -284,6 +286,8 @@ public class HealthCheckService : IHealthCheckService
                 }
             }
 
+            PruneArrHealthStatuses(results.Keys);
+
             return results;
         }
         catch (Exception ex)
@@ -308,6 +312,38 @@ public class HealthCheckService : IHealthCheckService
         lock (_lockObject)
         {
             return new Dictionary<Guid, ArrHealthStatus>(_arrHealthStatuses);
+        }
+    }
+
+    /// <summary>
+    /// Drops cached clients that have been invalidated.
+    /// </summary>
+    private void PruneClientHealthStatuses(IEnumerable<Guid> checkedClientIds)
+    {
+        HashSet<Guid> live = checkedClientIds.ToHashSet();
+
+        lock (_lockObject)
+        {
+            foreach (Guid stale in _healthStatuses.Keys.Where(id => !live.Contains(id)).ToList())
+            {
+                _healthStatuses.Remove(stale);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Drops cached arr instances that have been invalidated.
+    /// </summary>
+    private void PruneArrHealthStatuses(IEnumerable<Guid> checkedInstanceIds)
+    {
+        HashSet<Guid> live = checkedInstanceIds.ToHashSet();
+
+        lock (_lockObject)
+        {
+            foreach (Guid stale in _arrHealthStatuses.Keys.Where(id => !live.Contains(id)).ToList())
+            {
+                _arrHealthStatuses.Remove(stale);
+            }
         }
     }
 

--- a/code/backend/Cleanuparr.Infrastructure/Health/HealthCheckService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/HealthCheckService.cs
@@ -116,8 +116,8 @@ public class HealthCheckService : IHealthCheckService
     {
         _logger.LogDebug("Checking health for all enabled clients");
 
-        // Captured before anything is awaited: an entry written later belongs to a newer check.
-        HashSet<Guid> knownAtStart = SnapshotClientIds();
+        // Captured before anything is awaited: a later check replaces the instance and survives the prune.
+        Dictionary<Guid, HealthStatus> knownAtStart = SnapshotClients();
 
         try
         {
@@ -137,7 +137,7 @@ public class HealthCheckService : IHealthCheckService
                 results[clientConfig.Id] = status;
             }
             
-            PruneClientHealthStatuses(results.Keys, knownAtStart);
+            PruneClientHealthStatuses(knownAtStart);
             
             return results;
         }
@@ -241,8 +241,8 @@ public class HealthCheckService : IHealthCheckService
     {
         _logger.LogDebug("Checking health for all enabled arr instances");
 
-        // Captured before anything is awaited: an entry written later belongs to a newer check.
-        HashSet<Guid> knownAtStart = SnapshotArrInstanceIds();
+        // Captured before anything is awaited: a later check replaces the instance and survives the prune.
+        Dictionary<Guid, ArrHealthStatus> knownAtStart = SnapshotArrInstances();
 
         try
         {
@@ -302,7 +302,7 @@ public class HealthCheckService : IHealthCheckService
                 }
             }
 
-            PruneArrHealthStatuses(results.Keys, knownAtStart);
+            PruneArrHealthStatuses(knownAtStart);
 
             return results;
         }
@@ -334,33 +334,41 @@ public class HealthCheckService : IHealthCheckService
     /// <summary>
     /// Drops cached clients that have been invalidated.
     /// </summary>
-    private HashSet<Guid> SnapshotClientIds()
+    private Dictionary<Guid, HealthStatus> SnapshotClients()
     {
         lock (_lockObject)
         {
-            return _healthStatuses.Keys.ToHashSet();
+            return new Dictionary<Guid, HealthStatus>(_healthStatuses);
         }
     }
 
-    private HashSet<Guid> SnapshotArrInstanceIds()
+    private Dictionary<Guid, ArrHealthStatus> SnapshotArrInstances()
     {
         lock (_lockObject)
         {
-            return _arrHealthStatuses.Keys.ToHashSet();
+            return new Dictionary<Guid, ArrHealthStatus>(_arrHealthStatuses);
         }
     }
 
-    private void PruneClientHealthStatuses(IEnumerable<Guid> checkedClientIds, HashSet<Guid> knownAtStart)
+    /// <summary>
+    /// Drops cached clients that have been invalidated.
+    /// </summary>
+    private void PruneClientHealthStatuses(Dictionary<Guid, HealthStatus> knownAtStart)
     {
-        HashSet<Guid> live = checkedClientIds.ToHashSet();
         List<Guid> removed = [];
 
         lock (_lockObject)
         {
-            foreach (Guid stale in knownAtStart.Where(id => !live.Contains(id)).ToList())
+            foreach ((Guid clientId, HealthStatus snapshot) in knownAtStart)
             {
-                _healthStatuses.Remove(stale);
-                removed.Add(stale);
+                if (!_healthStatuses.TryGetValue(clientId, out HealthStatus? cached)
+                    || !ReferenceEquals(cached, snapshot))
+                {
+                    continue;
+                }
+
+                _healthStatuses.Remove(clientId);
+                removed.Add(clientId);
             }
         }
 
@@ -374,17 +382,22 @@ public class HealthCheckService : IHealthCheckService
     /// <summary>
     /// Drops cached arr instances that have been invalidated.
     /// </summary>
-    private void PruneArrHealthStatuses(IEnumerable<Guid> checkedInstanceIds, HashSet<Guid> knownAtStart)
+    private void PruneArrHealthStatuses(Dictionary<Guid, ArrHealthStatus> knownAtStart)
     {
-        HashSet<Guid> live = checkedInstanceIds.ToHashSet();
         List<Guid> removed = [];
 
         lock (_lockObject)
         {
-            foreach (Guid stale in knownAtStart.Where(id => !live.Contains(id)).ToList())
+            foreach ((Guid instanceId, ArrHealthStatus snapshot) in knownAtStart)
             {
-                _arrHealthStatuses.Remove(stale);
-                removed.Add(stale);
+                if (!_arrHealthStatuses.TryGetValue(instanceId, out ArrHealthStatus? cached)
+                    || !ReferenceEquals(cached, snapshot))
+                {
+                    continue;
+                }
+
+                _arrHealthStatuses.Remove(instanceId);
+                removed.Add(instanceId);
             }
         }
 

--- a/code/backend/Cleanuparr.Infrastructure/Health/HealthStatusBroadcaster.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/HealthStatusBroadcaster.cs
@@ -59,13 +59,13 @@ public class HealthStatusBroadcaster : IHostedService
     {
         try
         {
-            _logger.LogDebug("Broadcasting health status removal for arr instance {instanceId}", e.InstanceId);
+            _logger.LogDebug("Broadcasting health status removal for arr instance {InstanceId}", e.InstanceId);
 
             await _hubContext.Clients.All.SendAsync("ArrInstanceRemoved", e.InstanceId);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error broadcasting health status removal for arr instance {instanceId}", e.InstanceId);
+            _logger.LogError(ex, "Error broadcasting health status removal for arr instance {InstanceId}", e.InstanceId);
         }
     }
 
@@ -73,13 +73,13 @@ public class HealthStatusBroadcaster : IHostedService
     {
         try
         {
-            _logger.LogDebug("Broadcasting health status removal for client {clientId}", e.ClientId);
+            _logger.LogDebug("Broadcasting health status removal for client {ClientId}", e.ClientId);
 
             await _hubContext.Clients.All.SendAsync("ClientRemoved", e.ClientId);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error broadcasting health status removal for client {clientId}", e.ClientId);
+            _logger.LogError(ex, "Error broadcasting health status removal for client {ClientId}", e.ClientId);
         }
     }
 
@@ -87,7 +87,7 @@ public class HealthStatusBroadcaster : IHostedService
     {
         try
         {
-            _logger.LogDebug("Broadcasting health status change for client {clientId}", e.ClientId);
+            _logger.LogDebug("Broadcasting health status change for client {ClientId}", e.ClientId);
             
             // Broadcast to all clients
             await _hubContext.Clients.All.SendAsync("HealthStatusChanged", e.Status);
@@ -95,20 +95,20 @@ public class HealthStatusBroadcaster : IHostedService
             // Send degradation messages
             if (e.IsDegraded)
             {
-                _logger.LogWarning("Client {clientId} health degraded", e.ClientId);
+                _logger.LogWarning("Client {ClientId} health degraded", e.ClientId);
                 await _hubContext.Clients.All.SendAsync("ClientDegraded", e.Status);
             }
             
             // Send recovery messages
             if (e.IsRecovered)
             {
-                _logger.LogInformation("Client {clientId} health recovered", e.ClientId);
+                _logger.LogInformation("Client {ClientId} health recovered", e.ClientId);
                 await _hubContext.Clients.All.SendAsync("ClientRecovered", e.Status);
             }
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error broadcasting health status change for client {clientId}", e.ClientId);
+            _logger.LogError(ex, "Error broadcasting health status change for client {ClientId}", e.ClientId);
         }
     }
 }

--- a/code/backend/Cleanuparr.Infrastructure/Health/HealthStatusBroadcaster.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/HealthStatusBroadcaster.cs
@@ -37,6 +37,7 @@ public class HealthStatusBroadcaster : IHostedService
         // Subscribe to health status change events
         _healthCheckService.ClientHealthChanged += OnClientHealthChanged;
         _healthCheckService.ClientHealthRemoved += OnClientHealthRemoved;
+        _healthCheckService.ArrInstanceHealthRemoved += OnArrInstanceHealthRemoved;
         
         return Task.CompletedTask;
     }
@@ -49,10 +50,25 @@ public class HealthStatusBroadcaster : IHostedService
         // Unsubscribe from health status change events
         _healthCheckService.ClientHealthChanged -= OnClientHealthChanged;
         _healthCheckService.ClientHealthRemoved -= OnClientHealthRemoved;
+        _healthCheckService.ArrInstanceHealthRemoved -= OnArrInstanceHealthRemoved;
         
         return Task.CompletedTask;
     }
     
+    private async void OnArrInstanceHealthRemoved(object? sender, ArrInstanceHealthRemovedEventArgs e)
+    {
+        try
+        {
+            _logger.LogDebug("Broadcasting health status removal for arr instance {instanceId}", e.InstanceId);
+
+            await _hubContext.Clients.All.SendAsync("ArrInstanceRemoved", e.InstanceId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error broadcasting health status removal for arr instance {instanceId}", e.InstanceId);
+        }
+    }
+
     private async void OnClientHealthRemoved(object? sender, ClientHealthRemovedEventArgs e)
     {
         try

--- a/code/backend/Cleanuparr.Infrastructure/Health/HealthStatusBroadcaster.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/HealthStatusBroadcaster.cs
@@ -36,6 +36,7 @@ public class HealthStatusBroadcaster : IHostedService
         
         // Subscribe to health status change events
         _healthCheckService.ClientHealthChanged += OnClientHealthChanged;
+        _healthCheckService.ClientHealthRemoved += OnClientHealthRemoved;
         
         return Task.CompletedTask;
     }
@@ -47,10 +48,25 @@ public class HealthStatusBroadcaster : IHostedService
         
         // Unsubscribe from health status change events
         _healthCheckService.ClientHealthChanged -= OnClientHealthChanged;
+        _healthCheckService.ClientHealthRemoved -= OnClientHealthRemoved;
         
         return Task.CompletedTask;
     }
     
+    private async void OnClientHealthRemoved(object? sender, ClientHealthRemovedEventArgs e)
+    {
+        try
+        {
+            _logger.LogDebug("Broadcasting health status removal for client {clientId}", e.ClientId);
+
+            await _hubContext.Clients.All.SendAsync("ClientRemoved", e.ClientId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error broadcasting health status removal for client {clientId}", e.ClientId);
+        }
+    }
+
     private async void OnClientHealthChanged(object? sender, ClientHealthChangedEventArgs e)
     {
         try

--- a/code/backend/Cleanuparr.Infrastructure/Health/IHealthCheckService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/IHealthCheckService.cs
@@ -16,6 +16,11 @@ public interface IHealthCheckService
     event EventHandler<ClientHealthRemovedEventArgs> ClientHealthRemoved;
 
     /// <summary>
+    /// Occurs when an arr instance is no longer covered by the health sweep
+    /// </summary>
+    event EventHandler<ArrInstanceHealthRemovedEventArgs> ArrInstanceHealthRemoved;
+
+    /// <summary>
     /// Checks the health of a specific download client
     /// </summary>
     /// <param name="clientId">The client ID to check</param>

--- a/code/backend/Cleanuparr.Infrastructure/Health/IHealthCheckService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Health/IHealthCheckService.cs
@@ -11,6 +11,11 @@ public interface IHealthCheckService
     event EventHandler<ClientHealthChangedEventArgs> ClientHealthChanged;
 
     /// <summary>
+    /// Occurs when a client is no longer covered by the health sweep
+    /// </summary>
+    event EventHandler<ClientHealthRemovedEventArgs> ClientHealthRemoved;
+
+    /// <summary>
     /// Checks the health of a specific download client
     /// </summary>
     /// <param name="clientId">The client ID to check</param>


### PR DESCRIPTION
The health status of download clients and arr clients are periodically checked, but they are also cached until the next health check run. The cache only grew in size, having stale entries until the app restarted.