### PR TITLE
Fix Download Cleaner crashing on torrents deleted from qBittorrent mid-run

### DIFF
--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/QBitServiceDCTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/QBitServiceDCTests.cs
@@ -195,6 +195,152 @@ public class QBitServiceDCTests : IClassFixture<QBitServiceFixture>
             result.ShouldHaveSingleItem();
             result[0].Hash.ShouldBe("hash1");
         }
+
+        [Fact]
+        public async Task SkipsTorrent_WhenTrackersAreNull()
+        {
+            // Arrange
+            QBitService sut = _fixture.CreateSut();
+
+            TorrentInfo[] torrentList =
+            [
+                new TorrentInfo { Hash = "hash1", Name = "Deleted Torrent", State = TorrentState.Uploading },
+                new TorrentInfo { Hash = "hash2", Name = "Live Torrent", State = TorrentState.Uploading }
+            ];
+
+            _fixture.ClientWrapper
+                .GetTorrentListAsync(Arg.Is<TorrentListQuery>(q => q.Filter == TorrentListFilter.Completed))
+                .Returns(torrentList);
+
+            _fixture.ClientWrapper
+                .GetTorrentTrackersAsync("hash1")
+                .Returns((IReadOnlyList<TorrentTracker>?)null);
+
+            _fixture.ClientWrapper
+                .GetTorrentTrackersAsync("hash2")
+                .Returns(Array.Empty<TorrentTracker>());
+
+            _fixture.ClientWrapper
+                .GetTorrentPropertiesAsync(Arg.Any<string>())
+                .Returns(PublicProperties());
+
+            // Act
+            List<ITorrentItemWrapper> result = await sut.GetSeedingDownloads();
+
+            // Assert
+            result.ShouldHaveSingleItem();
+            result[0].Hash.ShouldBe("hash2");
+        }
+
+        [Fact]
+        public async Task SkipsTorrent_WhenPropertiesAreNull()
+        {
+            // Arrange
+            QBitService sut = _fixture.CreateSut();
+
+            TorrentInfo[] torrentList =
+            [
+                new TorrentInfo { Hash = "hash1", Name = "Deleted Torrent", State = TorrentState.Uploading }
+            ];
+
+            _fixture.ClientWrapper
+                .GetTorrentListAsync(Arg.Is<TorrentListQuery>(q => q.Filter == TorrentListFilter.Completed))
+                .Returns(torrentList);
+
+            _fixture.ClientWrapper
+                .GetTorrentTrackersAsync("hash1")
+                .Returns(Array.Empty<TorrentTracker>());
+
+            _fixture.ClientWrapper
+                .GetTorrentPropertiesAsync("hash1")
+                .Returns((TorrentProperties?)null);
+
+            // Act
+            List<ITorrentItemWrapper> result = await sut.GetSeedingDownloads();
+
+            // Assert
+            result.ShouldBeEmpty();
+        }
+
+        [Fact]
+        public async Task KeepsTorrent_WhenOnlyPseudoTrackersArePresent()
+        {
+            // Arrange
+            QBitService sut = _fixture.CreateSut();
+
+            TorrentInfo[] torrentList =
+            [
+                new TorrentInfo { Hash = "hash1", Name = "Trackerless Torrent", State = TorrentState.Uploading }
+            ];
+
+            _fixture.ClientWrapper
+                .GetTorrentListAsync(Arg.Is<TorrentListQuery>(q => q.Filter == TorrentListFilter.Completed))
+                .Returns(torrentList);
+
+            _fixture.ClientWrapper
+                .GetTorrentTrackersAsync("hash1")
+                .Returns(new TorrentTracker[]
+                {
+                    new() { Url = "** [DHT] **", TrackerStatus = TorrentTrackerStatus.Working },
+                    new() { Url = "** [PeX] **", TrackerStatus = TorrentTrackerStatus.Working },
+                    new() { Url = "** [LSD] **", TrackerStatus = TorrentTrackerStatus.Working }
+                });
+
+            _fixture.ClientWrapper
+                .GetTorrentPropertiesAsync("hash1")
+                .Returns(PublicProperties());
+
+            // Act
+            List<ITorrentItemWrapper> result = await sut.GetSeedingDownloads();
+
+            // Assert
+            result.ShouldHaveSingleItem();
+            result[0].TrackerDomains.ShouldBeEmpty();
+            result[0].TrackerHealth.ShouldBe(TrackerHealth.Unsupported);
+        }
+
+        [Fact]
+        public async Task KeepsTorrent_WhenATrackerUrlIsNull()
+        {
+            // Arrange
+            QBitService sut = _fixture.CreateSut();
+
+            TorrentInfo[] torrentList =
+            [
+                new TorrentInfo { Hash = "hash1", Name = "Torrent 1", State = TorrentState.Uploading }
+            ];
+
+            _fixture.ClientWrapper
+                .GetTorrentListAsync(Arg.Is<TorrentListQuery>(q => q.Filter == TorrentListFilter.Completed))
+                .Returns(torrentList);
+
+            _fixture.ClientWrapper
+                .GetTorrentTrackersAsync("hash1")
+                .Returns(new TorrentTracker[]
+                {
+                    new() { Url = null!, TrackerStatus = TorrentTrackerStatus.Working },
+                    new() { Url = "http://tracker.example.com/announce", TrackerStatus = TorrentTrackerStatus.Working }
+                });
+
+            _fixture.ClientWrapper
+                .GetTorrentPropertiesAsync("hash1")
+                .Returns(PublicProperties());
+
+            // Act
+            List<ITorrentItemWrapper> result = await sut.GetSeedingDownloads();
+
+            // Assert
+            result.ShouldHaveSingleItem();
+            result[0].TrackerDomains.ShouldHaveSingleItem();
+        }
+
+        private static TorrentProperties PublicProperties() => new()
+        {
+            AdditionalData = new Dictionary<string, Newtonsoft.Json.Linq.JToken>
+            {
+                { "is_private", Newtonsoft.Json.Linq.JToken.FromObject(false) }
+            }
+        };
     }
 
     public class FilterDownloadsToBeCleanedAsync_Tests : QBitServiceDCTests

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/QBitServiceTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/QBitServiceTests.cs
@@ -246,6 +246,85 @@ public class QBitServiceTests : IClassFixture<QBitServiceFixture>
             result.DeleteReason.ShouldBe(DeleteReason.None);
             result.DeleteFromClient.ShouldBeFalse();
         }
+
+        [Fact]
+        public async Task TorrentTrackersNotFound_ReturnsEmptyResult()
+        {
+            // Arrange
+            const string hash = "test-hash";
+            QBitService sut = _fixture.CreateSut();
+
+            TorrentInfo torrentInfo = new()
+            {
+                Hash = hash,
+                Name = "Deleted Torrent",
+                State = TorrentState.Downloading
+            };
+
+            _fixture.ClientWrapper
+                .GetTorrentListAsync(Arg.Is<TorrentListQuery>(q => q.Hashes != null && q.Hashes.Contains(hash)))
+                .Returns(new[] { torrentInfo });
+
+            _fixture.ClientWrapper
+                .GetTorrentTrackersAsync(hash)
+                .Returns((IReadOnlyList<TorrentTracker>?)null);
+
+            // Act
+            DownloadCheckResult result = await sut.ShouldRemoveFromArrQueueAsync(hash, Array.Empty<string>());
+
+            // Assert
+            result.Found.ShouldBeFalse();
+            result.ShouldRemove.ShouldBeFalse();
+            result.DeleteReason.ShouldBe(DeleteReason.None);
+            await _fixture.ClientWrapper.DidNotReceive().GetTorrentPropertiesAsync(hash);
+        }
+
+        [Fact]
+        public async Task TorrentWithOnlyPseudoTrackers_IsFound()
+        {
+            // Arrange
+            const string hash = "test-hash";
+            QBitService sut = _fixture.CreateSut();
+
+            TorrentInfo torrentInfo = new()
+            {
+                Hash = hash,
+                Name = "Trackerless Torrent",
+                State = TorrentState.Downloading
+            };
+
+            _fixture.ClientWrapper
+                .GetTorrentListAsync(Arg.Is<TorrentListQuery>(q => q.Hashes != null && q.Hashes.Contains(hash)))
+                .Returns(new[] { torrentInfo });
+
+            _fixture.ClientWrapper
+                .GetTorrentTrackersAsync(hash)
+                .Returns(new TorrentTracker[]
+                {
+                    new() { Url = "** [DHT] **", TrackerStatus = TorrentTrackerStatus.Working }
+                });
+
+            _fixture.ClientWrapper
+                .GetTorrentPropertiesAsync(hash)
+                .Returns(new TorrentProperties
+                {
+                    AdditionalData = new Dictionary<string, Newtonsoft.Json.Linq.JToken>
+                    {
+                        { "is_private", Newtonsoft.Json.Linq.JToken.FromObject(false) }
+                    }
+                });
+
+            _fixture.RuleEvaluator
+                .EvaluateStallRulesAsync(Arg.Any<QBitItemWrapper>())
+                .Returns((false, DeleteReason.None, false, false));
+
+            // Act
+            DownloadCheckResult result = await sut.ShouldRemoveFromArrQueueAsync(hash, Array.Empty<string>());
+
+            // Assert
+            result.Found.ShouldBeTrue();
+            result.Torrent!.TrackerDomains.ShouldBeEmpty();
+        }
     }
 
     public class ShouldRemoveFromArrQueueAsync_AllFilesSkippedScenarios : QBitServiceTests
@@ -1406,6 +1485,58 @@ public class QBitServiceTests : IClassFixture<QBitServiceFixture>
             result.Found.ShouldBeTrue();
             result.ShouldRemove.ShouldBeFalse();
             result.DeleteReason.ShouldBe(DeleteReason.None);
+        }
+
+        [Fact]
+        public async Task TrackersNotFound_ReturnsNotFound()
+        {
+            const string hash = "deleted-hash";
+            QBitService sut = _fixture.CreateSut();
+            SetMalwareBlockerContext();
+
+            _fixture.ClientWrapper
+                .GetTorrentListAsync(Arg.Is<TorrentListQuery>(q => q.Hashes != null && q.Hashes.Contains(hash)))
+                .Returns(new[] { MakeTorrentInfo(hash) });
+
+            _fixture.ClientWrapper
+                .GetTorrentTrackersAsync(hash)
+                .Returns((IReadOnlyList<TorrentTracker>?)null);
+
+            BlockFilesResult result = await sut.BlockUnwantedFilesAsync(hash, Array.Empty<string>());
+
+            result.Found.ShouldBeFalse();
+            result.ShouldRemove.ShouldBeFalse();
+            await _fixture.ClientWrapper.DidNotReceive()
+                .SetFilePriorityAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<TorrentContentPriority>());
+        }
+
+        [Fact]
+        public async Task OnlyPseudoTrackers_StillChecksFiles()
+        {
+            const string hash = "trackerless-hash";
+            QBitService sut = _fixture.CreateSut();
+            SetMalwareBlockerContext();
+
+            StubClient(hash,
+            [
+                new TorrentContent { Name = "installer.exe", Index = 0, Priority = TorrentContentPriority.Normal },
+            ]);
+
+            _fixture.ClientWrapper
+                .GetTorrentTrackersAsync(hash)
+                .Returns(new TorrentTracker[]
+                {
+                    new() { Url = "** [DHT] **", TrackerStatus = TorrentTrackerStatus.Working }
+                });
+
+            _fixture.FilenameEvaluator
+                .IsValid(Arg.Any<string>(), Arg.Any<BlocklistType>(), Arg.Any<ConcurrentBag<string>>(), Arg.Any<ConcurrentBag<Regex>>())
+                .Returns(false);
+
+            BlockFilesResult result = await sut.BlockUnwantedFilesAsync(hash, Array.Empty<string>());
+
+            result.Found.ShouldBeTrue();
+            result.ShouldRemove.ShouldBeTrue();
         }
     }
 }

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/IQBittorrentClientWrapper.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/IQBittorrentClientWrapper.cs
@@ -11,7 +11,7 @@ public interface IQBittorrentClientWrapper : IDisposable
     Task<ApiVersion> GetApiVersionAsync();
     Task<IReadOnlyList<TorrentInfo>> GetTorrentListAsync(TorrentListQuery query);
     Task<TorrentProperties?> GetTorrentPropertiesAsync(string hash);
-    Task<IReadOnlyList<TorrentContent>> GetTorrentContentsAsync(string hash);
+    Task<IReadOnlyList<TorrentContent>?> GetTorrentContentsAsync(string hash);
     Task<IReadOnlyList<TorrentTracker>?> GetTorrentTrackersAsync(string hash);
     Task<IReadOnlyDictionary<string, Category>> GetCategoriesAsync();
     Task AddCategoryAsync(string category);

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/IQBittorrentClientWrapper.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/IQBittorrentClientWrapper.cs
@@ -12,7 +12,7 @@ public interface IQBittorrentClientWrapper : IDisposable
     Task<IReadOnlyList<TorrentInfo>> GetTorrentListAsync(TorrentListQuery query);
     Task<TorrentProperties?> GetTorrentPropertiesAsync(string hash);
     Task<IReadOnlyList<TorrentContent>> GetTorrentContentsAsync(string hash);
-    Task<IReadOnlyList<TorrentTracker>> GetTorrentTrackersAsync(string hash);
+    Task<IReadOnlyList<TorrentTracker>?> GetTorrentTrackersAsync(string hash);
     Task<IReadOnlyDictionary<string, Category>> GetCategoriesAsync();
     Task AddCategoryAsync(string category);
     Task DeleteAsync(IEnumerable<string> hashes, bool deleteDownloadedData);

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitService.cs
@@ -69,18 +69,18 @@ public partial class QBitService : DownloadService, IQBitService
     {
         if (string.IsNullOrEmpty(_downloadClientConfig.Username) && string.IsNullOrEmpty(_downloadClientConfig.Password))
         {
-            _logger.LogDebug("No credentials configured for client {clientId}, skipping login", _downloadClientConfig.Id);
+            _logger.LogDebug("No credentials configured for client {ClientId}, skipping login", _downloadClientConfig.Id);
             return;
         }
 
         try
         {
             await _client.LoginAsync(_downloadClientConfig.Username, _downloadClientConfig.Password);
-            _logger.LogDebug("Successfully logged in to qBittorrent client {clientId}", _downloadClientConfig.Id);
+            _logger.LogDebug("Successfully logged in to qBittorrent client {ClientId}", _downloadClientConfig.Id);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to login to qBittorrent client {clientId}", _downloadClientConfig.Id);
+            _logger.LogError(ex, "Failed to login to qBittorrent client {ClientId}", _downloadClientConfig.Id);
             throw;
         }
     }
@@ -98,13 +98,13 @@ public partial class QBitService : DownloadService, IQBitService
             {
                 // If credentials are provided, we must be able to log in for the service to be healthy
                 await _client.LoginAsync(_downloadClientConfig.Username, _downloadClientConfig.Password);
-                _logger.LogDebug("Health check: Successfully logged in to qBittorrent client {clientId}", _downloadClientConfig.Id);
+                _logger.LogDebug("Health check: Successfully logged in to qBittorrent client {ClientId}", _downloadClientConfig.Id);
             }
             else
             {
                 // If no credentials, test connectivity using version endpoint
                 await _client.GetApiVersionAsync();
-                _logger.LogDebug("Health check: Successfully connected to qBittorrent client {clientId}", _downloadClientConfig.Id);
+                _logger.LogDebug("Health check: Successfully connected to qBittorrent client {ClientId}", _downloadClientConfig.Id);
             }
 
             stopwatch.Stop();
@@ -119,7 +119,7 @@ public partial class QBitService : DownloadService, IQBitService
         {
             stopwatch.Stop();
             
-            _logger.LogWarning(ex, "Health check failed for qBittorrent client {clientId}", _downloadClientConfig.Id);
+            _logger.LogWarning(ex, "Health check failed for qBittorrent client {ClientId}", _downloadClientConfig.Id);
             
             return new HealthCheckResult
             {
@@ -175,7 +175,7 @@ public partial class QBitService : DownloadService, IQBitService
         }
         catch (Exception ex)
         {
-            _logger.LogWarning(ex, "Failed to read alternate speed limits state from qBittorrent client {name}", _downloadClientConfig.Name);
+            _logger.LogWarning(ex, "Failed to read alternate speed limits state from qBittorrent client {Name}", _downloadClientConfig.Name);
             throw;
         }
 

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitService.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitService.cs
@@ -147,10 +147,18 @@ public partial class QBitService : DownloadService, IQBitService
         await _client.SetPreferencesAsync(preferences);
     }
     
-    private async Task<IReadOnlyList<TorrentTracker>> GetTrackersAsync(string hash)
+    /// <summary>
+    /// Reads the real trackers of a torrent, dropping the "** [DHT] **" style pseudo-rows.
+    /// </summary>
+    /// <returns>
+    /// An empty list for a trackerless torrent, or null when qBittorrent no longer knows the hash.
+    /// </returns>
+    private async Task<IReadOnlyList<TorrentTracker>?> GetTrackersAsync(string hash)
     {
-        return (await _client.GetTorrentTrackersAsync(hash))
-            .Where(x => !x.Url.Contains("**"))
+        IReadOnlyList<TorrentTracker>? trackers = await _client.GetTorrentTrackersAsync(hash);
+
+        return trackers
+            ?.Where(x => x.Url?.Contains("**") is not true)
             .ToList();
     }
     

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitServiceCB.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitServiceCB.cs
@@ -24,8 +24,14 @@ public partial class QBitService
             return result;
         }
         
-        IReadOnlyList<TorrentTracker> trackers = await GetTrackersAsync(hash);
-        
+        IReadOnlyList<TorrentTracker>? trackers = await GetTrackersAsync(hash);
+
+        if (trackers is null)
+        {
+            _logger.LogDebug("failed to find torrent {hash} in the {name} download client", hash, _downloadClientConfig.Name);
+            return result;
+        }
+
         if (ignoredDownloads.Count > 0 &&
             (download.ShouldIgnore(ignoredDownloads) || trackers.Any(x => x.ShouldIgnore(ignoredDownloads)) is true))
         {

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitServiceCB.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitServiceCB.cs
@@ -20,7 +20,7 @@ public partial class QBitService
 
         if (download is null)
         {
-            _logger.LogDebug("failed to find torrent {hash} in the {name} download client", hash, _downloadClientConfig.Name);
+            _logger.LogDebug("failed to find torrent {Hash} in the {Name} download client", hash, _downloadClientConfig.Name);
             return result;
         }
         
@@ -28,14 +28,14 @@ public partial class QBitService
 
         if (trackers is null)
         {
-            _logger.LogDebug("failed to find torrent {hash} in the {name} download client", hash, _downloadClientConfig.Name);
+            _logger.LogDebug("failed to find torrent {Hash} in the {Name} download client", hash, _downloadClientConfig.Name);
             return result;
         }
 
         if (ignoredDownloads.Count > 0 &&
             (download.ShouldIgnore(ignoredDownloads) || trackers.Any(x => x.ShouldIgnore(ignoredDownloads)) is true))
         {
-            _logger.LogInformation("skip | download is ignored | {name}", download.Name);
+            _logger.LogInformation("skip | download is ignored | {Name}", download.Name);
             return result;
         }
         
@@ -43,7 +43,7 @@ public partial class QBitService
 
         if (torrentProperties is null)
         {
-            _logger.LogError("Failed to find torrent properties {name}", download.Name);
+            _logger.LogError("Failed to find torrent properties {Name}", download.Name);
             return result;
         }
 
@@ -61,7 +61,7 @@ public partial class QBitService
         if (malwareBlockerConfig.IgnorePrivate && isPrivate)
         {
             // ignore private trackers
-            _logger.LogDebug("skip files check | download is private | {name}", download.Name);
+            _logger.LogDebug("skip files check | download is private | {Name}", download.Name);
             return result;
         }
         
@@ -69,7 +69,7 @@ public partial class QBitService
 
         if (files?.Count is null or 0)
         {
-            _logger.LogDebug("skip files check | no files found | {name}", download.Name);
+            _logger.LogDebug("skip files check | no files found | {Name}", download.Name);
             return result;
         }
 
@@ -86,7 +86,7 @@ public partial class QBitService
         {
             if (!file.Index.HasValue)
             {
-                _logger.LogTrace("Skipping file with no index | {file}", file.Name);
+                _logger.LogTrace("Skipping file with no index | {File}", file.Name);
                 continue;
             }
 
@@ -94,22 +94,22 @@ public partial class QBitService
 
             if (file.Priority is TorrentContentPriority.Skip)
             {
-                _logger.LogTrace("File is already skipped | {file}", file.Name);
+                _logger.LogTrace("File is already skipped | {File}", file.Name);
                 totalUnwantedFiles++;
                 continue;
             }
 
             if (_filenameEvaluator.IsValid(file.Name, blocklistType, patterns, regexes))
             {
-                _logger.LogTrace("File is valid | {file}", file.Name);
+                _logger.LogTrace("File is valid | {File}", file.Name);
                 continue;
             }
             
-            _logger.LogInformation("unwanted file found | {file}", file.Name);
+            _logger.LogInformation("unwanted file found | {File}", file.Name);
 
             if (malwareBlockerConfig.DeleteIfAnyFileBlocked)
             {
-                _logger.LogDebug("at least one file is blocked for {name}", download.Name);
+                _logger.LogDebug("at least one file is blocked for {Name}", download.Name);
                 result.ShouldRemove = true;
                 result.DeleteReason = DeleteReason.AtLeastOneFileBlocked;
                 return result;
@@ -121,18 +121,18 @@ public partial class QBitService
 
         if (unwantedFiles.Count is 0)
         {
-            _logger.LogDebug("No unwanted files found for {name}", download.Name);
+            _logger.LogDebug("No unwanted files found for {Name}", download.Name);
             return result;
         }
         
         if (totalUnwantedFiles == totalFiles)
         {
-            _logger.LogDebug("All files are blocked for {name}", download.Name);
+            _logger.LogDebug("All files are blocked for {Name}", download.Name);
             result.ShouldRemove = true;
             result.DeleteReason = DeleteReason.AllFilesBlocked;
         }
         
-        _logger.LogDebug("Marking {count} unwanted files as skipped for {name}", totalUnwantedFiles, download.Name);
+        _logger.LogDebug("Marking {Count} unwanted files as skipped for {Name}", totalUnwantedFiles, download.Name);
 
         foreach (int fileIndex in unwantedFiles)
         {

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitServiceDC.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitServiceDC.cs
@@ -23,11 +23,9 @@ public partial class QBitService
         var result = new List<ITorrentItemWrapper>();
         foreach (var torrent in torrentList.Where(x => !string.IsNullOrEmpty(x.Hash)))
         {
-            IReadOnlyList<TorrentTracker>? trackers = await GetTrackersAsync(torrent.Hash!);
-            TorrentProperties? properties = await _client.GetTorrentPropertiesAsync(torrent.Hash!);
+            IReadOnlyList<TorrentTracker>? trackers = await GetTrackersAsync(torrent.Hash);
+            TorrentProperties? properties = await _client.GetTorrentPropertiesAsync(torrent.Hash);
 
-            // Both calls 404 once the torrent is deleted, and a missing privacy flag would
-            // otherwise read as public and match the wrong seeding rule.
             if (trackers is null || properties is null)
             {
                 _logger.LogDebug("skip | torrent no longer exists in the download client | {name}", torrent.Name);

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitServiceDC.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitServiceDC.cs
@@ -4,6 +4,7 @@ using Cleanuparr.Infrastructure.Features.Context;
 using Cleanuparr.Persistence.Models.Configuration.DownloadCleaner;
 using Cleanuparr.Shared.Helpers;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
 using QBittorrent.Client;
 
 namespace Cleanuparr.Infrastructure.Features.DownloadClient.QBittorrent;
@@ -22,9 +23,18 @@ public partial class QBitService
         var result = new List<ITorrentItemWrapper>();
         foreach (var torrent in torrentList.Where(x => !string.IsNullOrEmpty(x.Hash)))
         {
-            var trackers = await GetTrackersAsync(torrent.Hash!);
-            var properties = await _client.GetTorrentPropertiesAsync(torrent.Hash!);
-            bool isPrivate = properties?.AdditionalData.TryGetValue("is_private", out var dictValue) == true &&
+            IReadOnlyList<TorrentTracker>? trackers = await GetTrackersAsync(torrent.Hash!);
+            TorrentProperties? properties = await _client.GetTorrentPropertiesAsync(torrent.Hash!);
+
+            // Both calls 404 once the torrent is deleted, and a missing privacy flag would
+            // otherwise read as public and match the wrong seeding rule.
+            if (trackers is null || properties is null)
+            {
+                _logger.LogDebug("skip | torrent no longer exists in the download client | {name}", torrent.Name);
+                continue;
+            }
+
+            bool isPrivate = properties.AdditionalData.TryGetValue("is_private", out JToken? dictValue) &&
                            bool.TryParse(dictValue?.ToString(), out bool boolValue) && boolValue;
 
             result.Add(new QBitItemWrapper(torrent, trackers, isPrivate));

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitServiceDC.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitServiceDC.cs
@@ -28,7 +28,7 @@ public partial class QBitService
 
             if (trackers is null || properties is null)
             {
-                _logger.LogDebug("skip | torrent no longer exists in the download client | {name}", torrent.Name);
+                _logger.LogDebug("skip | torrent no longer exists in the download client | {Name}", torrent.Name);
                 continue;
             }
 
@@ -116,7 +116,7 @@ public partial class QBitService
             return;
         }
 
-        _logger.LogDebug("Creating category {name}", name);
+        _logger.LogDebug("Creating category {Name}", name);
 
         await _dryRunInterceptor.InterceptAsync(() => CreateCategory(name));
     }
@@ -139,7 +139,7 @@ public partial class QBitService
 
             if (files is null)
             {
-                _logger.LogDebug("failed to find files for {name}", torrent.Name);
+                _logger.LogDebug("failed to find files for {Name}", torrent.Name);
                 continue;
             }
 
@@ -153,7 +153,7 @@ public partial class QBitService
             {
                 if (!file.Index.HasValue)
                 {
-                    _logger.LogDebug("skip | file index is null for {name}", torrent.Name);
+                    _logger.LogDebug("skip | file index is null for {Name}", torrent.Name);
                     hasHardlinks = true;
                     break;
                 }
@@ -165,7 +165,7 @@ public partial class QBitService
 
                 if (file.Priority is TorrentContentPriority.Skip)
                 {
-                    _logger.LogDebug("skip | file is not downloaded | {file}", filePath);
+                    _logger.LogDebug("skip | file is not downloaded | {File}", filePath);
                     continue;
                 }
 
@@ -173,7 +173,7 @@ public partial class QBitService
 
                 if (hardlinkCount < 0)
                 {
-                    _logger.LogError("skip | file does not exist or insufficient permissions | {file}", filePath);
+                    _logger.LogError("skip | file does not exist or insufficient permissions | {File}", filePath);
                     hasErrors = true;
                     break;
                 }
@@ -192,7 +192,7 @@ public partial class QBitService
 
             if (hasHardlinks)
             {
-                _logger.LogDebug("skip | download has hardlinks | {name}", torrent.Name);
+                _logger.LogDebug("skip | download has hardlinks | {Name}", torrent.Name);
                 continue;
             }
 
@@ -202,11 +202,11 @@ public partial class QBitService
 
             if (unlinkedConfig.UseTag)
             {
-                _logger.LogInformation("tag added for {name}", torrent.Name);
+                _logger.LogInformation("tag added for {Name}", torrent.Name);
             }
             else
             {
-                _logger.LogInformation("category changed for {name}", torrent.Name);
+                _logger.LogInformation("category changed for {Name}", torrent.Name);
                 torrent.Category = unlinkedConfig.TargetCategory;
             }
         }

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitServiceQC.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitServiceQC.cs
@@ -19,7 +19,7 @@ public partial class QBitService
 
         if (download is null)
         {
-            _logger.LogDebug("Failed to find torrent {hash} in the {name} download client", hash, _downloadClientConfig.Name);
+            _logger.LogDebug("Failed to find torrent {Hash} in the {Name} download client", hash, _downloadClientConfig.Name);
             return result;
         }
 
@@ -27,7 +27,7 @@ public partial class QBitService
 
         if (trackers is null)
         {
-            _logger.LogDebug("Failed to find torrent {hash} in the {name} download client", hash, _downloadClientConfig.Name);
+            _logger.LogDebug("Failed to find torrent {Hash} in the {Name} download client", hash, _downloadClientConfig.Name);
             return result;
         }
 
@@ -35,7 +35,7 @@ public partial class QBitService
 
         if (torrentProperties is null)
         {
-            _logger.LogError("Failed to find torrent properties for {name}", download.Name);
+            _logger.LogError("Failed to find torrent properties for {Name}", download.Name);
             return result;
         }
 
@@ -52,7 +52,7 @@ public partial class QBitService
 
         if (torrent.IsIgnored(ignoredDownloads))
         {
-            _logger.LogInformation("skip | download is ignored | {name}", torrent.Name);
+            _logger.LogInformation("skip | download is ignored | {Name}", torrent.Name);
             return result;
         }
 
@@ -65,14 +65,14 @@ public partial class QBitService
             // if all files were blocked by qBittorrent
             if (download is { CompletionOn: not null, Downloaded: null or 0 })
             {
-                _logger.LogDebug("all files are unwanted by qBit | removing download | {name}", torrent.Name);
+                _logger.LogDebug("all files are unwanted by qBit | removing download | {Name}", torrent.Name);
                 result.DeleteReason = DeleteReason.AllFilesSkippedByQBit;
                 result.DeleteFromClient = true;
                 return result;
             }
 
             // remove if all files are unwanted
-            _logger.LogDebug("all files are unwanted | removing download | {name}", torrent.Name);
+            _logger.LogDebug("all files are unwanted | removing download | {Name}", torrent.Name);
             result.DeleteReason = DeleteReason.AllFilesSkipped;
             result.DeleteFromClient = true;
             return result;
@@ -99,13 +99,13 @@ public partial class QBitService
     {
         if (!wrapper.IsDownloading())
         {
-            _logger.LogTrace("skip slow check | download is not in downloading state | {name}", wrapper.Name);
+            _logger.LogTrace("skip slow check | download is not in downloading state | {Name}", wrapper.Name);
             return (false, DeleteReason.None, false, false);
         }
 
         if (wrapper.DownloadSpeed <= 0)
         {
-            _logger.LogTrace("skip slow check | download speed is 0 | {name}", wrapper.Name);
+            _logger.LogTrace("skip slow check | download speed is 0 | {Name}", wrapper.Name);
             return (false, DeleteReason.None, false, false);
         }
 
@@ -135,7 +135,7 @@ public partial class QBitService
 
         if (!wrapper.IsStalled())
         {
-            _logger.LogTrace("skip stalled check | download is not in stalled state | {name}", wrapper.Name);
+            _logger.LogTrace("skip stalled check | download is not in stalled state | {Name}", wrapper.Name);
             return (false, DeleteReason.None, false, false);
         }
 

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitServiceQC.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBitServiceQC.cs
@@ -23,7 +23,13 @@ public partial class QBitService
             return result;
         }
 
-        IReadOnlyList<TorrentTracker> trackers = await GetTrackersAsync(hash);
+        IReadOnlyList<TorrentTracker>? trackers = await GetTrackersAsync(hash);
+
+        if (trackers is null)
+        {
+            _logger.LogDebug("Failed to find torrent {hash} in the {name} download client", hash, _downloadClientConfig.Name);
+            return result;
+        }
 
         TorrentProperties? torrentProperties = await _client.GetTorrentPropertiesAsync(hash);
 

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBittorrentClientWrapper.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBittorrentClientWrapper.cs
@@ -29,7 +29,7 @@ public sealed class QBittorrentClientWrapper : IQBittorrentClientWrapper
     public Task<IReadOnlyList<TorrentContent>> GetTorrentContentsAsync(string hash)
         => _client.GetTorrentContentsAsync(hash);
 
-    public Task<IReadOnlyList<TorrentTracker>> GetTorrentTrackersAsync(string hash)
+    public Task<IReadOnlyList<TorrentTracker>?> GetTorrentTrackersAsync(string hash)
         => _client.GetTorrentTrackersAsync(hash);
 
     public Task<IReadOnlyDictionary<string, Category>> GetCategoriesAsync()

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBittorrentClientWrapper.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/QBittorrent/QBittorrentClientWrapper.cs
@@ -26,7 +26,7 @@ public sealed class QBittorrentClientWrapper : IQBittorrentClientWrapper
     public Task<TorrentProperties?> GetTorrentPropertiesAsync(string hash)
         => _client.GetTorrentPropertiesAsync(hash);
 
-    public Task<IReadOnlyList<TorrentContent>> GetTorrentContentsAsync(string hash)
+    public Task<IReadOnlyList<TorrentContent>?> GetTorrentContentsAsync(string hash)
         => _client.GetTorrentContentsAsync(hash);
 
     public Task<IReadOnlyList<TorrentTracker>?> GetTorrentTrackersAsync(string hash)

--- a/e2e/tests/download-cleaner/vanished-torrent-race.spec.ts
+++ b/e2e/tests/download-cleaner/vanished-torrent-race.spec.ts
@@ -25,10 +25,23 @@ const CATEGORY = 'vanish-race';
  * Enough torrents that the enumeration loop stays busy while the deleter runs.
  * The loop issues two requests per torrent, the deleter one.
  */
-const TORRENT_COUNT = 120;
+const TORRENT_COUNT = 200;
 
-/** Deleting from the tail leaves the head of the list for the loop to finish. */
-const DELETE_INTERVAL_MS = 10;
+/**
+ * Head of the list, never deleted.
+ * Survivors keep an empty seeding pass from reading as the crash.
+ */
+const SURVIVOR_COUNT = 40;
+
+/**
+ * Spreads the deletions over seconds.
+ * Enumeration lasts under 100ms and starts whenever Quartz gets to it, so the
+ * deleter has to still be working wherever in that span the pass lands.
+ */
+const DELETE_INTERVAL_MS = 30;
+
+/** Logged once per run, after every client has been enumerated. */
+const ENUMERATION_FINISHED = /Found (\d+) seeding downloads across \d+ clients/;
 
 const qbit = new QBittorrentDriver();
 
@@ -74,11 +87,11 @@ test.describe.serial('Download Cleaner with torrents deleted mid-pass', () => {
       ignoredDownloads: [],
     });
 
-    // The skip decision is only observable at debug level.
+    // The skip decision needs debug, the enumeration markers need verbose.
     const general = await getGeneralConfig(token);
     const log = general.log as Record<string, unknown>;
     originalLogLevel = log.level;
-    await updateGeneralConfig(token, { ...general, log: { ...log, level: 'Debug' } });
+    await updateGeneralConfig(token, { ...general, log: { ...log, level: 'Verbose' } });
 
     mkdirShared(HOST_DOWNLOADS);
   });
@@ -145,29 +158,33 @@ test.describe.serial('Download Cleaner with torrents deleted mid-pass', () => {
     const trig = await triggerJob(token, 'DownloadCleaner');
     expect(trig.ok, `triggerJob: ${trig.status}`).toBe(true);
 
-    // Deleting from the tail while the loop reads from the head is what opens
-    // the window between the bulk list call and the per-hash calls.
-    for (const hash of [...hashes].reverse()) {
+    // The cleaner reads the list head to tail, the deleter walks it tail to head.
+    // Where the two meet, a listed torrent is gone before its per-hash call.
+    for (const hash of [...hashes].slice(SURVIVOR_COUNT).reverse()) {
       await qbit.deleteTorrent(hash).catch(() => {});
       await sleep(DELETE_INTERVAL_MS);
     }
 
     await expect
-      .poll(() => appLogsSince(since).includes('torrent no longer exists in the download client'), {
-        message: 'the race never landed: no torrent vanished between the list call and its per-hash calls',
+      .poll(() => ENUMERATION_FINISHED.test(appLogsSince(since)), {
+        message: 'the cleaner never finished enumerating',
         timeout: 60_000,
         intervals: [1_000],
       })
       .toBe(true);
 
     const logs = appLogsSince(since);
+    expect(logs, 'the race never landed: no torrent vanished mid-pass').toContain(
+      'torrent no longer exists in the download client',
+    );
     expect(logs, 'the vanished torrent crashed the pass').not.toContain('ArgumentNullException');
     expect(logs, 'the cleanup pass aborted for the client').not.toContain(
       'Failed to get seeding downloads from download client',
     );
-    // The crash discarded every torrent enriched before it, leaving the pass with nothing.
-    expect(logs, 'the surviving torrents were discarded along with the vanished one').not.toContain(
-      'No seeding downloads found',
-    );
+
+    // The crash discarded every torrent enriched before the vanished one.
+    const seeding = Number(logs.match(ENUMERATION_FINISHED)![1]);
+    expect(seeding, 'the surviving torrents were discarded along with the vanished ones')
+      .toBeGreaterThanOrEqual(SURVIVOR_COUNT);
   });
 });

--- a/e2e/tests/download-cleaner/vanished-torrent-race.spec.ts
+++ b/e2e/tests/download-cleaner/vanished-torrent-race.spec.ts
@@ -1,0 +1,173 @@
+import { test, expect } from '@playwright/test';
+import { join, resolve } from 'node:path';
+import {
+  loginAndGetToken,
+  createDownloadClient,
+  listDownloadClients,
+  deleteDownloadClient,
+  updateDownloadCleanerConfig,
+  getDownloadCleanerConfig,
+  getGeneralConfig,
+  updateGeneralConfig,
+  triggerJob,
+} from '../helpers/app-api';
+import { appLogsSince } from '../helpers/test-lifecycle';
+import { QBittorrentDriver } from '../helpers/torrent-clients/qbittorrent';
+import { buildSingleFileTorrent, resetDirectory } from '../helpers/torrent-fixtures';
+import { mkdirShared } from '../helpers/shared-volume';
+
+const HOST_DOWNLOADS = resolve(__dirname, '..', '..', 'test-data', 'downloads');
+const CLIENT_DOWNLOADS = '/downloads';
+const ANNOUNCE_HOST = 'http://127.0.0.1:6969/announce';
+const CATEGORY = 'vanish-race';
+
+/**
+ * Enough torrents that the enumeration loop stays busy while the deleter runs.
+ * The loop issues two requests per torrent, the deleter one.
+ */
+const TORRENT_COUNT = 120;
+
+/** Deleting from the tail leaves the head of the list for the loop to finish. */
+const DELETE_INTERVAL_MS = 10;
+
+const qbit = new QBittorrentDriver();
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** The seeding pass reads this filter, so a torrent only counts once it appears here. */
+async function completedCount(): Promise<number> {
+  const res = await fetch('http://localhost:8090/api/v2/torrents/info?filter=completed');
+  if (!res.ok) {
+    throw new Error(`qBittorrent completed list failed: ${res.status}`);
+  }
+  return ((await res.json()) as unknown[]).length;
+}
+
+/**
+ * A torrent deleted between the bulk list call and its own per-hash call makes
+ * qBittorrent answer 404, which the client library turns into a null list.
+ *
+ * Issue #779: that null reached a LINQ call and threw ArgumentNullException out
+ * of GetSeedingDownloads, discarding every torrent already enriched and
+ * skipping the client for the whole cleanup pass.
+ */
+test.describe.serial('Download Cleaner with torrents deleted mid-pass', () => {
+  let token: string;
+  let clientId: string | undefined;
+  let originalLogLevel: unknown;
+  let hashes: string[] = [];
+
+  test.beforeAll(async () => {
+    token = await loginAndGetToken();
+
+    for (const c of await listDownloadClients(token)) {
+      await deleteDownloadClient(token, c.id);
+    }
+
+    const dc = await (await getDownloadCleanerConfig(token)).json();
+    await updateDownloadCleanerConfig(token, {
+      enabled: true,
+      cronExpression: dc.cronExpression || '0 0 * * * ?',
+      useAdvancedScheduling: dc.useAdvancedScheduling ?? false,
+      ignoredDownloads: [],
+    });
+
+    // The skip decision is only observable at debug level.
+    const general = await getGeneralConfig(token);
+    const log = general.log as Record<string, unknown>;
+    originalLogLevel = log.level;
+    await updateGeneralConfig(token, { ...general, log: { ...log, level: 'Debug' } });
+
+    mkdirShared(HOST_DOWNLOADS);
+  });
+
+  test.afterAll(async () => {
+    await qbit.clearAllTorrents().catch(() => {});
+    if (clientId) {
+      await deleteDownloadClient(token, clientId).catch(() => {});
+    }
+    const general = await getGeneralConfig(token);
+    const log = general.log as Record<string, unknown>;
+    await updateGeneralConfig(token, { ...general, log: { ...log, level: originalLogLevel } }).catch(() => {});
+  });
+
+  test('seeds a torrent set large enough to race', async () => {
+    test.setTimeout(300_000);
+
+    const dir = join(HOST_DOWNLOADS, 'qbittorrent');
+    resetDirectory(dir);
+    mkdirShared(dir);
+
+    await qbit.ready();
+    await qbit.clearAllTorrents();
+
+    for (let i = 0; i < TORRENT_COUNT; i++) {
+      const fx = buildSingleFileTorrent(dir, `vanish-race-${i}.bin`, 1024, ANNOUNCE_HOST);
+      await qbit.addSeedingTorrent({
+        metainfo: fx.metainfo,
+        savePath: CLIENT_DOWNLOADS,
+        category: CATEGORY,
+        infoHash: fx.infoHash,
+      });
+    }
+
+    await expect
+      .poll(completedCount, {
+        message: 'not every torrent reached the completed state',
+        timeout: 120_000,
+        intervals: [1_000],
+      })
+      .toBe(TORRENT_COUNT);
+
+    hashes = (await qbit.listTorrents()).map((t) => t.hash);
+
+    const createRes = await createDownloadClient(token, {
+      enabled: true,
+      name: 'qBittorrent vanish race e2e',
+      typeName: qbit.typeName,
+      type: 'Torrent',
+      host: qbit.cleanuparrHost,
+      username: qbit.username ?? '',
+      password: qbit.password ?? '',
+    });
+    expect(createRes.status).toBeGreaterThanOrEqual(200);
+    expect(createRes.status).toBeLessThan(300);
+    clientId = (await createRes.json()).id;
+  });
+
+  test('skips the vanished torrents instead of aborting the pass', async () => {
+    test.setTimeout(300_000);
+
+    const since = new Date().toISOString();
+
+    const trig = await triggerJob(token, 'DownloadCleaner');
+    expect(trig.ok, `triggerJob: ${trig.status}`).toBe(true);
+
+    // Deleting from the tail while the loop reads from the head is what opens
+    // the window between the bulk list call and the per-hash calls.
+    for (const hash of [...hashes].reverse()) {
+      await qbit.deleteTorrent(hash).catch(() => {});
+      await sleep(DELETE_INTERVAL_MS);
+    }
+
+    await expect
+      .poll(() => appLogsSince(since).includes('torrent no longer exists in the download client'), {
+        message: 'the race never landed: no torrent vanished between the list call and its per-hash calls',
+        timeout: 60_000,
+        intervals: [1_000],
+      })
+      .toBe(true);
+
+    const logs = appLogsSince(since);
+    expect(logs, 'the vanished torrent crashed the pass').not.toContain('ArgumentNullException');
+    expect(logs, 'the cleanup pass aborted for the client').not.toContain(
+      'Failed to get seeding downloads from download client',
+    );
+    // The crash discarded every torrent enriched before it, leaving the pass with nothing.
+    expect(logs, 'the surviving torrents were discarded along with the vanished one').not.toContain(
+      'No seeding downloads found',
+    );
+  });
+});


### PR DESCRIPTION
Relates to #779.

qBittorrent responds with a 404 when a torrent is deleted between the seeding list call and its per-hash calls (e.g. properties, trackers). The removed torrent is now skipped instead of aborting the job run.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>