### PR TITLE
Fix uTorrent including deleted torrents in the seeding list

### DIFF
--- a/code/backend/Cleanuparr.Domain/Entities/UTorrent/Response/PropertiesResponse.cs
+++ b/code/backend/Cleanuparr.Domain/Entities/UTorrent/Response/PropertiesResponse.cs
@@ -16,8 +16,8 @@ public sealed class PropertiesResponse
     public JsonElement[]? PropertiesRaw { get; set; }
 
     /// <summary>
-    /// Parsed properties as strongly-typed object
+    /// Parsed properties as strongly-typed object, or null when µTorrent does not know the hash
     /// </summary>
     [JsonIgnore]
-    public UTorrentProperties Properties { get; set; } = new();
+    public UTorrentProperties? Properties { get; set; }
 }

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/UTorrent/UTorrentResponseParserTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/UTorrent/UTorrentResponseParserTests.cs
@@ -363,18 +363,16 @@ public class UTorrentResponseParserTests
     }
 
     [Fact]
-    public void ParseProperties_EmptyPropsArray_ReturnsDefaultProperties()
+    public void ParseProperties_EmptyPropsArray_ReturnsNoProperties()
     {
-        // Arrange
+        // Arrange — µTorrent answers this way for a hash it no longer holds
         const string json = """{"props": []}""";
 
         // Act
         var response = _parser.ParseProperties(json);
 
-        // Assert — no parsing happens; Properties stays at the empty default
-        response.Properties.ShouldNotBeNull();
-        response.Properties!.Hash.ShouldBe(string.Empty);
-        response.Properties.IsPrivate.ShouldBeFalse();
+        // Assert
+        response.Properties.ShouldBeNull();
     }
 
     [Fact]

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/UTorrentServiceDCTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/UTorrentServiceDCTests.cs
@@ -105,6 +105,38 @@ public class UTorrentServiceDCTests : IClassFixture<UTorrentServiceFixture>
             result.ShouldHaveSingleItem();
             result[0].Hash.ShouldBe("hash1");
         }
+
+        [Fact]
+        public async Task SkipsTorrent_WhenPropertiesAreNull()
+        {
+            // Arrange
+            UTorrentService sut = _fixture.CreateSut();
+
+            List<UTorrentItem> torrents =
+            [
+                new UTorrentItem { Hash = "hash1", Name = "Deleted Torrent", Status = 9, DateCompleted = 1000 },
+                new UTorrentItem { Hash = "hash2", Name = "Live Torrent", Status = 9, DateCompleted = 2000 }
+            ];
+
+            _fixture.ClientWrapper
+                .GetTorrentsAsync()
+                .Returns(torrents);
+
+            _fixture.ClientWrapper
+                .GetTorrentPropertiesAsync("hash1")
+                .Returns((UTorrentProperties?)null);
+
+            _fixture.ClientWrapper
+                .GetTorrentPropertiesAsync("hash2")
+                .Returns(new UTorrentProperties { Hash = "hash2", Pex = 1, Trackers = "" });
+
+            // Act
+            List<ITorrentItemWrapper> result = await sut.GetSeedingDownloads();
+
+            // Assert
+            result.ShouldHaveSingleItem();
+            result[0].Hash.ShouldBe("hash2");
+        }
     }
 
     public class FilterDownloadsToBeCleanedAsync_Tests : UTorrentServiceDCTests

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/UTorrentServiceTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/UTorrentServiceTests.cs
@@ -47,6 +47,27 @@ public class UTorrentServiceTests : IClassFixture<UTorrentServiceFixture>
         }
 
         [Fact]
+        public async Task TorrentPropertiesNotFound_ReturnsEmptyResult()
+        {
+            const string hash = "deleted-hash";
+            UTorrentService sut = _fixture.CreateSut();
+
+            _fixture.ClientWrapper
+                .GetTorrentAsync(hash)
+                .Returns(new UTorrentItem { Hash = hash, Name = "Deleted Torrent", Status = 9 });
+
+            _fixture.ClientWrapper
+                .GetTorrentPropertiesAsync(hash)
+                .Returns((UTorrentProperties?)null);
+
+            DownloadCheckResult result = await sut.ShouldRemoveFromArrQueueAsync(hash, Array.Empty<string>());
+
+            result.Found.ShouldBeFalse();
+            result.ShouldRemove.ShouldBeFalse();
+            result.DeleteReason.ShouldBe(DeleteReason.None);
+        }
+
+        [Fact]
         public async Task TorrentFound_SetsIsPrivateCorrectly_WhenPrivate()
         {
             const string hash = "test-hash";
@@ -888,6 +909,28 @@ public class UTorrentServiceTests : IClassFixture<UTorrentServiceFixture>
             result.Found.ShouldBeTrue();
             result.ShouldRemove.ShouldBeFalse();
             result.DeleteReason.ShouldBe(DeleteReason.None);
+        }
+
+        [Fact]
+        public async Task PropertiesNotFound_ReturnsNotFound()
+        {
+            const string hash = "deleted-hash";
+            UTorrentService sut = _fixture.CreateSut();
+            SetMalwareBlockerContext();
+
+            _fixture.ClientWrapper
+                .GetTorrentAsync(hash)
+                .Returns(new UTorrentItem { Hash = hash, Name = "Deleted Torrent", Status = 9 });
+
+            _fixture.ClientWrapper
+                .GetTorrentPropertiesAsync(hash)
+                .Returns((UTorrentProperties?)null);
+
+            BlockFilesResult result = await sut.BlockUnwantedFilesAsync(hash, Array.Empty<string>());
+
+            result.Found.ShouldBeFalse();
+            result.ShouldRemove.ShouldBeFalse();
+            await _fixture.ClientWrapper.DidNotReceive().GetTorrentFilesAsync(hash);
         }
     }
 }

--- a/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/UTorrentServiceTests.cs
+++ b/code/backend/Cleanuparr.Infrastructure.Tests/Features/DownloadClient/UTorrentServiceTests.cs
@@ -932,5 +932,82 @@ public class UTorrentServiceTests : IClassFixture<UTorrentServiceFixture>
             result.ShouldRemove.ShouldBeFalse();
             await _fixture.ClientWrapper.DidNotReceive().GetTorrentFilesAsync(hash);
         }
+
+        [Fact]
+        public async Task TorrentNotFound_ReturnsNotFound()
+        {
+            const string hash = "missing-hash";
+            UTorrentService sut = _fixture.CreateSut();
+            SetMalwareBlockerContext();
+
+            _fixture.ClientWrapper
+                .GetTorrentAsync(hash)
+                .Returns((UTorrentItem?)null);
+
+            BlockFilesResult result = await sut.BlockUnwantedFilesAsync(hash, Array.Empty<string>());
+
+            result.Found.ShouldBeFalse();
+            result.ShouldRemove.ShouldBeFalse();
+            result.DeleteReason.ShouldBe(DeleteReason.None);
+            await _fixture.ClientWrapper.DidNotReceive().GetTorrentPropertiesAsync(hash);
+        }
+
+        [Fact]
+        public async Task IgnoredDownload_SkipsFileCheck()
+        {
+            const string hash = "ignored-hash";
+            UTorrentService sut = _fixture.CreateSut();
+            SetMalwareBlockerContext();
+
+            StubClient(hash,
+            [
+                new UTorrentFile { Name = "installer.exe", Index = 0, Priority = 2, Size = 1024, Downloaded = 1024 },
+            ]);
+
+            BlockFilesResult result = await sut.BlockUnwantedFilesAsync(hash, [hash]);
+
+            result.Found.ShouldBeTrue();
+            result.ShouldRemove.ShouldBeFalse();
+            result.DeleteReason.ShouldBe(DeleteReason.None);
+            await _fixture.ClientWrapper.DidNotReceive().GetTorrentFilesAsync(hash);
+        }
+
+        [Fact]
+        public async Task PrivateTorrent_WithIgnorePrivate_SkipsFileCheck()
+        {
+            const string hash = "private-hash";
+            UTorrentService sut = _fixture.CreateSut();
+            SetMalwareBlockerContext(new ContentBlockerConfig { IgnorePrivate = true });
+
+            StubClient(hash,
+            [
+                new UTorrentFile { Name = "installer.exe", Index = 0, Priority = 2, Size = 1024, Downloaded = 1024 },
+            ], isPrivate: true);
+
+            BlockFilesResult result = await sut.BlockUnwantedFilesAsync(hash, Array.Empty<string>());
+
+            result.Found.ShouldBeTrue();
+            result.IsPrivate.ShouldBeTrue();
+            result.ShouldRemove.ShouldBeFalse();
+            await _fixture.ClientWrapper.DidNotReceive().GetTorrentFilesAsync(hash);
+        }
+
+        [Fact]
+        public async Task NoFiles_SkipsFileCheck()
+        {
+            const string hash = "no-files-hash";
+            UTorrentService sut = _fixture.CreateSut();
+            SetMalwareBlockerContext();
+
+            StubClient(hash, []);
+
+            BlockFilesResult result = await sut.BlockUnwantedFilesAsync(hash, Array.Empty<string>());
+
+            result.Found.ShouldBeTrue();
+            result.ShouldRemove.ShouldBeFalse();
+            result.DeleteReason.ShouldBe(DeleteReason.None);
+            await _fixture.ClientWrapper.DidNotReceive()
+                .SetFilesPriorityAsync(Arg.Any<string>(), Arg.Any<List<int>>(), Arg.Any<int>());
+        }
     }
 }

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/IUTorrentClientWrapper.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/IUTorrentClientWrapper.cs
@@ -9,7 +9,7 @@ public interface IUTorrentClientWrapper
     Task<List<UTorrentItem>> GetTorrentsAsync();
     Task<UTorrentItem?> GetTorrentAsync(string hash);
     Task<List<UTorrentFile>?> GetTorrentFilesAsync(string hash);
-    Task<UTorrentProperties> GetTorrentPropertiesAsync(string hash);
+    Task<UTorrentProperties?> GetTorrentPropertiesAsync(string hash);
     Task<List<string>> GetLabelsAsync();
     Task SetTorrentLabelAsync(string hash, string label);
     Task SetFilesPriorityAsync(string hash, List<int> fileIndexes, int priority);

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentClient.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentClient.cs
@@ -131,7 +131,7 @@ public sealed class UTorrentClient
     /// </summary>
     /// <param name="hash">Torrent hash</param>
     /// <returns>UTorrentProperties object or null if not found</returns>
-    public async Task<UTorrentProperties> GetTorrentPropertiesAsync(string hash)
+    public async Task<UTorrentProperties?> GetTorrentPropertiesAsync(string hash)
     {
         try
         {

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentClientWrapper.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentClientWrapper.cs
@@ -26,7 +26,7 @@ public sealed class UTorrentClientWrapper : IUTorrentClientWrapper
     public Task<List<UTorrentFile>?> GetTorrentFilesAsync(string hash)
         => _client.GetTorrentFilesAsync(hash);
 
-    public Task<UTorrentProperties> GetTorrentPropertiesAsync(string hash)
+    public Task<UTorrentProperties?> GetTorrentPropertiesAsync(string hash)
         => _client.GetTorrentPropertiesAsync(hash);
 
     public Task<List<string>> GetLabelsAsync()

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentServiceCB.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentServiceCB.cs
@@ -26,7 +26,14 @@ public partial class UTorrentService
             return result;
         }
         
-        var properties = await _client.GetTorrentPropertiesAsync(hash);
+        UTorrentProperties? properties = await _client.GetTorrentPropertiesAsync(hash);
+
+        if (properties is null)
+        {
+            _logger.LogDebug("Failed to find torrent {hash} in the download client", hash);
+            return result;
+        }
+
         result.IsPrivate = properties.IsPrivate;
         result.Found = true;
         result.Torrent = new UTorrentItemWrapper(download, properties);

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentServiceCB.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentServiceCB.cs
@@ -22,7 +22,7 @@ public partial class UTorrentService
         
         if (download?.Hash is null)
         {
-            _logger.LogDebug("Failed to find torrent {hash} in the download client", hash);
+            _logger.LogDebug("Failed to find torrent {Hash} in the download client", hash);
             return result;
         }
         
@@ -30,7 +30,7 @@ public partial class UTorrentService
 
         if (properties is null)
         {
-            _logger.LogDebug("Failed to find torrent {hash} in the download client", hash);
+            _logger.LogDebug("Failed to find torrent {Hash} in the download client", hash);
             return result;
         }
 
@@ -42,7 +42,7 @@ public partial class UTorrentService
         if (ignoredDownloads.Count > 0 &&
             (download.ShouldIgnore(ignoredDownloads) || properties.TrackerList.Any(x => x.ShouldIgnore(ignoredDownloads))))
         {
-            _logger.LogInformation("skip | download is ignored | {name}", download.Name);
+            _logger.LogInformation("skip | download is ignored | {Name}", download.Name);
             return result;
         }
 
@@ -51,7 +51,7 @@ public partial class UTorrentService
         if (malwareBlockerConfig.IgnorePrivate && result.IsPrivate)
         {
             // ignore private trackers
-            _logger.LogDebug("skip files check | download is private | {name}", download.Name);
+            _logger.LogDebug("skip files check | download is private | {Name}", download.Name);
             return result;
         }
         
@@ -59,7 +59,7 @@ public partial class UTorrentService
 
         if (files?.Count is null or 0)
         {
-            _logger.LogDebug("skip files check | no files found | {name}", download.Name);
+            _logger.LogDebug("skip files check | no files found | {Name}", download.Name);
             return result;
         }
 
@@ -85,11 +85,11 @@ public partial class UTorrentService
             {
                 totalUnwantedFiles++;
                 fileIndexes.Add(i);
-                _logger.LogInformation("unwanted file found | {file}", file.Name);
+                _logger.LogInformation("unwanted file found | {File}", file.Name);
 
                 if (malwareBlockerConfig.DeleteIfAnyFileBlocked)
                 {
-                    _logger.LogDebug("at least one file is blocked for {name}", download.Name);
+                    _logger.LogDebug("at least one file is blocked for {Name}", download.Name);
                     result.ShouldRemove = true;
                     result.DeleteReason = DeleteReason.AtLeastOneFileBlocked;
                     return result;
@@ -102,11 +102,11 @@ public partial class UTorrentService
             return result;
         }
         
-        _logger.LogDebug("changing priorities | torrent {hash}", hash);
+        _logger.LogDebug("changing priorities | torrent {Hash}", hash);
 
         if (totalUnwantedFiles == files.Count)
         {
-            _logger.LogDebug("All files are blocked for {name}", download.Name);
+            _logger.LogDebug("All files are blocked for {Name}", download.Name);
             result.ShouldRemove = true;
             result.DeleteReason = DeleteReason.AllFilesBlocked;
         }

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentServiceDC.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentServiceDC.cs
@@ -22,7 +22,7 @@ public partial class UTorrentService
 
             if (properties is null)
             {
-                _logger.LogDebug("skip | torrent no longer exists in the download client | {name}", torrent.Name);
+                _logger.LogDebug("skip | torrent no longer exists in the download client | {Name}", torrent.Name);
                 continue;
             }
 
@@ -117,7 +117,7 @@ public partial class UTorrentService
 
                 if (file.Priority <= 0)
                 {
-                    _logger.LogDebug("skip | file is not downloaded | {file}", filePath);
+                    _logger.LogDebug("skip | file is not downloaded | {File}", filePath);
                     continue;
                 }
 
@@ -126,7 +126,7 @@ public partial class UTorrentService
 
                 if (hardlinkCount < 0)
                 {
-                    _logger.LogError("skip | file does not exist or insufficient permissions | {file}", filePath);
+                    _logger.LogError("skip | file does not exist or insufficient permissions | {File}", filePath);
                     hasErrors = true;
                     break;
                 }
@@ -145,7 +145,7 @@ public partial class UTorrentService
 
             if (hasHardlinks)
             {
-                _logger.LogDebug("skip | download has hardlinks | {name}", torrent.Name);
+                _logger.LogDebug("skip | download has hardlinks | {Name}", torrent.Name);
                 continue;
             }
 
@@ -153,7 +153,7 @@ public partial class UTorrentService
 
             await _eventPublisher.PublishCategoryChanged(torrent.Category, unlinkedConfig.TargetCategory);
 
-            _logger.LogInformation("category changed for {name}", torrent.Name);
+            _logger.LogInformation("category changed for {Name}", torrent.Name);
 
             torrent.Category = unlinkedConfig.TargetCategory;
         }

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentServiceDC.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentServiceDC.cs
@@ -18,7 +18,14 @@ public partial class UTorrentService
 
         foreach (UTorrentItem torrent in torrents.Where(x => !string.IsNullOrEmpty(x.Hash) && x.IsSeeding()))
         {
-            var properties = await _client.GetTorrentPropertiesAsync(torrent.Hash);
+            UTorrentProperties? properties = await _client.GetTorrentPropertiesAsync(torrent.Hash);
+
+            if (properties is null)
+            {
+                _logger.LogDebug("skip | torrent no longer exists in the download client | {name}", torrent.Name);
+                continue;
+            }
+
             result.Add(new UTorrentItemWrapper(torrent, properties));
         }
 

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentServiceQC.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentServiceQC.cs
@@ -25,7 +25,14 @@ public partial class UTorrentService
             return result;
         }
 
-        var properties = await _client.GetTorrentPropertiesAsync(hash);
+        UTorrentProperties? properties = await _client.GetTorrentPropertiesAsync(hash);
+
+        if (properties is null)
+        {
+            _logger.LogDebug("Failed to find torrent {hash} in the {name} download client", hash, _downloadClientConfig.Name);
+            return result;
+        }
+
         result.IsPrivate = properties.IsPrivate;
         result.Found = true;
         SetDownloadClientContext();

--- a/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentServiceQC.cs
+++ b/code/backend/Cleanuparr.Infrastructure/Features/DownloadClient/UTorrent/UTorrentServiceQC.cs
@@ -21,7 +21,7 @@ public partial class UTorrentService
 
         if (download?.Hash is null)
         {
-            _logger.LogDebug("Failed to find torrent {hash} in the {name} download client", hash, _downloadClientConfig.Name);
+            _logger.LogDebug("Failed to find torrent {Hash} in the {Name} download client", hash, _downloadClientConfig.Name);
             return result;
         }
 
@@ -29,7 +29,7 @@ public partial class UTorrentService
 
         if (properties is null)
         {
-            _logger.LogDebug("Failed to find torrent {hash} in the {name} download client", hash, _downloadClientConfig.Name);
+            _logger.LogDebug("Failed to find torrent {Hash} in the {Name} download client", hash, _downloadClientConfig.Name);
             return result;
         }
 
@@ -43,7 +43,7 @@ public partial class UTorrentService
 
         if (torrent.IsIgnored(ignoredDownloads))
         {
-            _logger.LogInformation("skip | download is ignored | {name}", torrent.Name);
+            _logger.LogInformation("skip | download is ignored | {Name}", torrent.Name);
             return result;
         }
 
@@ -53,7 +53,7 @@ public partial class UTorrentService
         }
         catch (Exception exception)
         {
-            _logger.LogWarning(exception, "Failed to get files for torrent {hash} in the download client", hash);
+            _logger.LogWarning(exception, "Failed to get files for torrent {Hash} in the download client", hash);
         }
 
         bool shouldRemove = files?.Count > 0;
@@ -70,7 +70,7 @@ public partial class UTorrentService
         if (shouldRemove)
         {
             // remove if all files are unwanted
-            _logger.LogDebug("all files are unwanted | removing download | {name}", torrent.Name);
+            _logger.LogDebug("all files are unwanted | removing download | {Name}", torrent.Name);
             result.ShouldRemove = true;
             result.DeleteReason = DeleteReason.AllFilesSkipped;
             result.DeleteFromClient = true;
@@ -100,13 +100,13 @@ public partial class UTorrentService
     {
         if (!wrapper.IsDownloading())
         {
-            _logger.LogTrace("skip slow check | download is not in downloading state | {name}", wrapper.Name);
+            _logger.LogTrace("skip slow check | download is not in downloading state | {Name}", wrapper.Name);
             return (false, DeleteReason.None, false, false);
         }
 
         if (wrapper.DownloadSpeed <= 0)
         {
-            _logger.LogTrace("skip slow check | download speed is 0 | {name}", wrapper.Name);
+            _logger.LogTrace("skip slow check | download speed is 0 | {Name}", wrapper.Name);
             return (false, DeleteReason.None, false, false);
         }
 
@@ -117,7 +117,7 @@ public partial class UTorrentService
     {
         if (!wrapper.IsStalled())
         {
-            _logger.LogTrace("skip stalled check | download is not in stalled state | {name}", wrapper.Name);
+            _logger.LogTrace("skip stalled check | download is not in stalled state | {Name}", wrapper.Name);
             return (false, DeleteReason.None, false, false);
         }
 


### PR DESCRIPTION
An unknown hash would return default properties, so a torrent that has been removed would be considered public and could match the wrong seeding rule.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>